### PR TITLE
fix: add TERM=xterm-256color to codebot container for proper color support

### DIFF
--- a/infra/bft/tasks/codebot.bft.ts
+++ b/infra/bft/tasks/codebot.bft.ts
@@ -146,6 +146,8 @@ function buildContainerArgs(config: ContainerConfig): Array<string> {
     "DISPLAY=:99", // Virtual display for headless Chrome
     "-e",
     "CODEBOT_CONTAINER=true", // Identify we're in a codebot container
+    "-e",
+    "TERM=xterm-256color", // Enable proper color support in terminal
   ];
 
   if (config.removeOnExit) {


### PR DESCRIPTION

The container's bashrc expects TERM to contain 'color' or '256color' to enable
color support, but it was only getting 'xterm'. This caused incorrect color
display in Claude Code within the container.

Also includes CODEBOT_CONTAINER=true from main branch to identify we're in a codebot container.
