### PR TITLE
Fix codebot syntax error and remove 1Password unlock from container

### DIFF
--- a/infra/apps/codebot/Dockerfile
+++ b/infra/apps/codebot/Dockerfile
@@ -201,8 +201,7 @@ if [ "\$CODEBOT_INITIALIZED" != "1" ]; then
   sl config --user ui.username "bft codebot <codebot@boltfoundry.com>"
   sl config --user isl.changedFilesDisplayType "tree"
   
-  # Get bf-codebot GitHub token from secrets
-  BF_CODEBOT_TOKEN=\$(bft secrets get BF_CODEBOT_GITHUB_TOKEN 2>/dev/null || echo "")
+  # BF_CODEBOT_TOKEN should be passed via environment variable from host
   
   # Configure GitHub authentication for bf-codebot
   if [ -n "\$BF_CODEBOT_TOKEN" ]; then

--- a/infra/apps/codebot/__tests__/bridge.integration.test.ts
+++ b/infra/apps/codebot/__tests__/bridge.integration.test.ts
@@ -7,14 +7,15 @@ import { startContainerBridge } from "../container-bridge.ts";
 const originalFetch = globalThis.fetch;
 
 Deno.test("host bridge - ping/pong endpoint", async () => {
-  const server = startHostBridge();
+  const port = 9018;
+  const server = startHostBridge(port);
 
   try {
     // Wait for server to start
     await delay(100);
 
     // Test /pong endpoint
-    const response = await fetch("http://localhost:8017/pong");
+    const response = await fetch(`http://localhost:${port}/pong`);
     assertEquals(response.status, 200);
 
     const data = await response.json();
@@ -67,13 +68,14 @@ Deno.test("host bridge - browser open endpoint", async () => {
     }
   } as unknown as typeof Deno.Command;
 
-  const server = startHostBridge();
+  const port = 9019;
+  const server = startHostBridge(port);
 
   try {
     await delay(100);
 
     // Test /browser/open endpoint
-    const response = await fetch("http://localhost:8017/browser/open", {
+    const response = await fetch(`http://localhost:${port}/browser/open`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ url: "http://test.codebot.local:8000" }),
@@ -93,12 +95,13 @@ Deno.test("host bridge - browser open endpoint", async () => {
 });
 
 Deno.test("host bridge - 404 for unknown endpoints", async () => {
-  const server = startHostBridge();
+  const port = 9020;
+  const server = startHostBridge(port);
 
   try {
     await delay(100);
 
-    const response = await fetch("http://localhost:8017/unknown");
+    const response = await fetch(`http://localhost:${port}/unknown`);
     assertEquals(response.status, 404);
     await response.text(); // Consume response body
   } finally {
@@ -110,13 +113,14 @@ Deno.test("container bridge - status endpoint", async () => {
   // Set workspace ID for testing
   Deno.env.set("WORKSPACE_ID", "test-workspace");
 
-  const server = startContainerBridge();
+  const port = 9021;
+  const server = startContainerBridge(port);
 
   try {
     await delay(100);
 
     // Test /status endpoint
-    const response = await fetch("http://localhost:8017/status");
+    const response = await fetch(`http://localhost:${port}/status`);
     assertEquals(response.status, 200);
 
     const data = await response.json();
@@ -157,13 +161,14 @@ Deno.test("container bridge - ping endpoint with host connectivity", async () =>
   };
 
   Deno.env.set("WORKSPACE_ID", "test-workspace");
-  const server = startContainerBridge();
+  const port = 9022;
+  const server = startContainerBridge(port);
 
   try {
     await delay(100);
 
     // Test /ping endpoint
-    const response = await fetch("http://localhost:8017/ping");
+    const response = await fetch(`http://localhost:${port}/ping`);
     assertEquals(response.status, 200);
 
     const data = await response.json();
@@ -196,13 +201,14 @@ Deno.test("container bridge - ping endpoint with host error", async () => {
   };
 
   Deno.env.set("WORKSPACE_ID", "test-workspace");
-  const server = startContainerBridge();
+  const port = 9023;
+  const server = startContainerBridge(port);
 
   try {
     await delay(100);
 
     // Test /ping endpoint with host error
-    const response = await fetch("http://localhost:8017/ping");
+    const response = await fetch(`http://localhost:${port}/ping`);
     assertEquals(response.status, 200);
 
     const data = await response.json();
@@ -222,11 +228,12 @@ Deno.test({
   name: "bidirectional communication - endpoints exist",
   fn: async () => {
     // Test that we can create both servers independently
-    const hostServer = startHostBridge();
+    const hostPort = 9024;
+    const hostServer = startHostBridge(hostPort);
     await delay(100);
 
     // Verify host bridge endpoints
-    const pongResponse = await fetch("http://localhost:8017/pong");
+    const pongResponse = await fetch(`http://localhost:${hostPort}/pong`);
     assertEquals(pongResponse.status, 200);
     await pongResponse.text();
 
@@ -235,11 +242,14 @@ Deno.test({
 
     // Now test container bridge
     Deno.env.set("WORKSPACE_ID", "test-workspace");
-    const containerServer = startContainerBridge();
+    const containerPort = 9025;
+    const containerServer = startContainerBridge(containerPort);
     await delay(100);
 
     // Verify container bridge endpoints
-    const statusResponse = await fetch("http://localhost:8017/status");
+    const statusResponse = await fetch(
+      `http://localhost:${containerPort}/status`,
+    );
     assertEquals(statusResponse.status, 200);
     const statusData = await statusResponse.json();
     assertEquals(statusData.ready, true);

--- a/infra/apps/codebot/container-bridge.ts
+++ b/infra/apps/codebot/container-bridge.ts
@@ -17,8 +17,8 @@ async function checkAppHealth(): Promise<boolean> {
   }
 }
 
-export function startContainerBridge() {
-  const server = Deno.serve({ port: 8017 }, async (req) => {
+export function startContainerBridge(port: number = 8017) {
+  const server = Deno.serve({ port }, async (req) => {
     const url = new URL(req.url);
     const workspaceId = getConfigurationVariable("WORKSPACE_ID") || "unknown";
 
@@ -70,7 +70,7 @@ export function startContainerBridge() {
     return new Response("Not Found", { status: 404 });
   });
 
-  logger.debug("🌉 Container bridge started on port 8017");
+  logger.debug(`🌉 Container bridge started on port ${port}`);
   return server;
 }
 

--- a/infra/apps/codebot/host-bridge.ts
+++ b/infra/apps/codebot/host-bridge.ts
@@ -2,9 +2,9 @@ import { getLogger } from "@bfmono/packages/logger/logger.ts";
 
 const logger = getLogger(import.meta);
 
-export function startHostBridge() {
+export function startHostBridge(port: number = 8017) {
   const server = Deno.serve(
-    { port: 8017 },
+    { port },
     async (req) => {
       const url = new URL(req.url);
 
@@ -63,7 +63,7 @@ export function startHostBridge() {
     },
   );
 
-  logger.debug("🌉 Host bridge started on port 8017");
+  logger.debug(`🌉 Host bridge started on port ${port}`);
   return server;
 }
 

--- a/infra/bft/tasks/codebot.bft.ts
+++ b/infra/bft/tasks/codebot.bft.ts
@@ -109,6 +109,7 @@ interface ContainerConfig {
   workspacePath: string;
   claudeDir: string;
   githubToken: string;
+  codebotToken: string;
   memory: string;
   cpus: string;
   interactive?: boolean;
@@ -134,6 +135,8 @@ function buildContainerArgs(config: ContainerConfig): Array<string> {
     "/tmp:/dev/shm", // Use host /tmp as shared memory for Chrome
     "-e",
     `GITHUB_TOKEN=${config.githubToken}`,
+    "-e",
+    `BF_CODEBOT_TOKEN=${config.codebotToken}`,
     "-e",
     "BF_E2E_MODE=true",
     "-e",
@@ -512,11 +515,14 @@ FIRST TIME SETUP:
 
   // Get GitHub token - first try codebot-specific token, then fall back to gh CLI
   let githubToken = "";
+  let codebotToken = ""; // BF_CODEBOT_TOKEN for container environment
 
   // First, check for codebot-specific GitHub token
-  const codebotToken = getConfigurationVariable("BF_CODEBOT_GITHUB_TOKEN");
-  if (codebotToken) {
-    githubToken = codebotToken;
+  const codebotGithubTokenFromConfig = getConfigurationVariable(
+    "BF_CODEBOT_GITHUB_TOKEN",
+  );
+  if (codebotGithubTokenFromConfig) {
+    githubToken = codebotGithubTokenFromConfig;
     ui.output("✅ Using codebot-specific GitHub token");
   } else {
     // Fall back to gh CLI token
@@ -535,6 +541,38 @@ FIRST TIME SETUP:
       // gh command not available or failed, continue without token
       ui.output("⚠️ No GitHub token found - some features may be limited");
     }
+  }
+
+  // Try to get BF_CODEBOT_GITHUB_TOKEN from environment or secrets
+  let codebotGithubToken =
+    getConfigurationVariable("BF_CODEBOT_GITHUB_TOKEN") || "";
+  if (!codebotGithubToken) {
+    try {
+      const secretsCmd = new Deno.Command("bft", {
+        args: ["secrets", "get", "BF_CODEBOT_GITHUB_TOKEN"],
+        stdout: "piped",
+        stderr: "null",
+      });
+      const secretsResult = await secretsCmd.output();
+      if (secretsResult.success) {
+        codebotGithubToken = new TextDecoder().decode(secretsResult.stdout)
+          .trim();
+      }
+    } catch {
+      // secrets command failed, continue without codebot token
+    }
+  }
+
+  // Use the token from env/secrets if we didn't get one from config
+  if (!githubToken && codebotGithubToken) {
+    githubToken = codebotGithubToken;
+    ui.output("✅ Using BF_CODEBOT_GITHUB_TOKEN from environment/secrets");
+  }
+
+  // Get BF_CODEBOT_TOKEN if available
+  const bfCodebotToken = getConfigurationVariable("BF_CODEBOT_TOKEN");
+  if (bfCodebotToken) {
+    codebotToken = bfCodebotToken;
   }
 
   // Handle workspace selection
@@ -1038,6 +1076,7 @@ FIRST TIME SETUP:
       workspacePath,
       claudeDir,
       githubToken,
+      codebotToken,
       memory: parsed.memory || autoMemory,
       cpus: parsed.cpus || autoCpus,
       interactive: true,
@@ -1128,6 +1167,7 @@ FIRST TIME SETUP:
       workspacePath,
       claudeDir,
       githubToken,
+      codebotToken,
       memory: parsed.memory || autoMemory,
       cpus: parsed.cpus || autoCpus,
       interactive: false,
@@ -1184,6 +1224,7 @@ FIRST TIME SETUP:
     workspacePath,
     claudeDir,
     githubToken,
+    codebotToken,
     memory: parsed.memory || autoMemory,
     cpus: parsed.cpus || autoCpus,
     interactive: true,


### PR DESCRIPTION

- Fixed duplicate declaration of codebotToken variable that was causing syntax error
- Removed bft secrets get call from container startup to prevent 1Password authentication
- BF_CODEBOT_TOKEN is now only passed via environment variable from host
- Cleaned up token handling logic to properly differentiate between GitHub token and codebot token

This ensures that bft secrets sync handles all secret management on the host side, and the container doesn't need to authenticate with 1Password.
