### PR TITLE
fix: Correct puppeteer-test-helper.sh path in Dockerfile.infra

### DIFF
--- a/infra/Dockerfile.infra
+++ b/infra/Dockerfile.infra
@@ -122,7 +122,7 @@ RUN npm install -g @anthropic-ai/claude-code
 RUN (google-chrome --version || chromium --version) || echo "WARNING: Chrome/Chromium may not be properly configured"
 
 # Copy Puppeteer test helper script
-COPY bfmono/infra/apps/codebot/puppeteer-test-helper.sh /usr/local/bin/puppeteer-test
+COPY infra/apps/codebot/puppeteer-test-helper.sh /usr/local/bin/puppeteer-test
 RUN chmod +x /usr/local/bin/puppeteer-test
 
 # Create entrypoint script that ensures /etc/hosts exists (must be done as root)


### PR DESCRIPTION

The Build and Push Codebot Container workflow was failing because the COPY
command was using an incorrect path. Changed from:
  COPY bfmono/infra/apps/codebot/puppeteer-test-helper.sh
to:
  COPY infra/apps/codebot/puppeteer-test-helper.sh

This fixes the Docker build error that was preventing the codebot container
from being built successfully.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/4).
* #5
* __->__ #4