### PR TITLE
fix: Remove invalid -debug flag and improve env var handling in Terraform workflows

### DIFF
--- a/.github/actions/debug-terraform-env/action.yml
+++ b/.github/actions/debug-terraform-env/action.yml
@@ -64,12 +64,15 @@ runs:
           echo '🔄 Sourcing and exporting variables...'
           source .env.secrets
 
-          # Export to GitHub env
-          {
-            echo \"TERRAFORM_S3_ENDPOINT=\$TERRAFORM_BACKEND_ENDPOINT\"
-            echo \"AWS_ACCESS_KEY_ID=\$TERRAFORM_BACKEND_ACCESS_KEY_ID\"
-            echo \"AWS_SECRET_ACCESS_KEY=\$TERRAFORM_BACKEND_SECRET_ACCESS_KEY\"
-          } >> \$GITHUB_ENV
+          # Debug: Show what we're about to export
+          echo ''
+          echo '📋 Variables to export:'
+          echo \"TERRAFORM_S3_ENDPOINT=\$TERRAFORM_BACKEND_ENDPOINT\"
+          
+          # Export to GitHub env - need to escape properly
+          echo \"TERRAFORM_S3_ENDPOINT=\$TERRAFORM_BACKEND_ENDPOINT\" >> \$GITHUB_ENV
+          echo \"AWS_ACCESS_KEY_ID=\$TERRAFORM_BACKEND_ACCESS_KEY_ID\" >> \$GITHUB_ENV
+          echo \"AWS_SECRET_ACCESS_KEY=\$TERRAFORM_BACKEND_SECRET_ACCESS_KEY\" >> \$GITHUB_ENV
 
           echo '✅ Variables exported to GitHub environment'
         " || {

--- a/.github/workflows/infrastructure-hetzner-debug.yml
+++ b/.github/workflows/infrastructure-hetzner-debug.yml
@@ -63,10 +63,19 @@ jobs:
           echo "=== Terraform Init Debug ==="
           echo "S3 Endpoint: ${TERRAFORM_S3_ENDPOINT:-NOT SET}"
           echo "AWS Access Key ID present: $([[ -n "$AWS_ACCESS_KEY_ID" ]] && echo "Yes" || echo "No")"
-
+          
+          # Debug: List all environment variables starting with TERRAFORM or AWS
+          echo ""
+          echo "=== Terraform/AWS Environment Variables ==="
+          env | grep -E '^(TERRAFORM|AWS)' | grep -v SECRET | sort || echo "No TERRAFORM/AWS vars found"
+          
+          # Check if endpoint is in env context
+          echo ""
+          echo "GitHub env TERRAFORM_S3_ENDPOINT: ${{ env.TERRAFORM_S3_ENDPOINT }}"
+          
+          # Initialize without -debug flag (not valid for init)
           terraform init \
-            -backend-config="endpoint=${{ env.TERRAFORM_S3_ENDPOINT }}" \
-            -debug
+            -backend-config="endpoint=${TERRAFORM_S3_ENDPOINT}"
 
       - name: Terraform Plan
         if: success()

--- a/debug-terraform-local.sh
+++ b/debug-terraform-local.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Local debug script for Terraform setup issues
+
+set -euo pipefail
+
+echo "=== Local Terraform Setup Debug ==="
+echo ""
+
+# Check if we're in the right directory
+if [ ! -f "flake.nix" ]; then
+    echo "❌ Error: Not in bfmono root directory"
+    echo "Please run this from /internalbf/bfmono"
+    exit 1
+fi
+
+echo "✅ Running from correct directory: $(pwd)"
+echo ""
+
+# Test nix develop
+echo "=== Testing Nix Environment ==="
+nix develop --accept-flake-config --command bash -c "
+    echo '✅ Entered nix develop successfully'
+    
+    # Check bft command
+    echo ''
+    echo '=== Testing bft command ==='
+    which bft || echo '❌ bft not found'
+    bft --version || echo '❌ Cannot get bft version'
+"
+
+# Test 1Password connection
+echo ""
+echo "=== Testing 1Password Connection ==="
+echo "Using OP_SERVICE_ACCOUNT_TOKEN from environment..."
+
+if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+    echo "❌ OP_SERVICE_ACCOUNT_TOKEN is not set"
+    echo "Please set it with: export OP_SERVICE_ACCOUNT_TOKEN='your-token'"
+    exit 1
+fi
+
+nix develop --accept-flake-config --command bash -c "
+    export OP_SERVICE_ACCOUNT_TOKEN='$OP_SERVICE_ACCOUNT_TOKEN'
+    
+    # Test op CLI
+    if command -v op &> /dev/null; then
+        echo '✅ op CLI found'
+        op vault list --format=json 2>&1 | jq -r '.[].name' || echo '❌ Failed to list vaults'
+    else
+        echo '❌ op CLI not found'
+    fi
+    
+    echo ''
+    echo '=== Testing bft sitevar ==='
+    bft sitevar list || echo '❌ bft sitevar list failed'
+    
+    echo ''
+    echo '=== Testing bft sitevar sync (dry run) ==='
+    bft sitevar sync --dry-run || echo '❌ bft sitevar sync dry run failed'
+    
+    echo ''
+    echo '=== Attempting actual sync ==='
+    read -p 'Run actual sync? (y/N): ' -n 1 -r
+    echo
+    if [[ \$REPLY =~ ^[Yy]$ ]]; then
+        bft sitevar sync --force
+        
+        echo ''
+        echo '=== Checking results ==='
+        if [ -f .env.secrets ]; then
+            echo '✅ .env.secrets created'
+            echo 'Required variables check:'
+            for var in HETZNER_API_TOKEN TERRAFORM_BACKEND_ACCESS_KEY_ID TERRAFORM_BACKEND_SECRET_ACCESS_KEY TERRAFORM_BACKEND_ENDPOINT; do
+                if grep -q \"^\${var}=\" .env.secrets; then
+                    echo \"  ✅ \$var is present\"
+                else
+                    echo \"  ❌ \$var is MISSING\"
+                fi
+            done
+        else
+            echo '❌ .env.secrets not created'
+        fi
+    fi
+"


### PR DESCRIPTION

- Remove -debug flag from terraform init (not a valid flag)
- Add debugging output to show which environment variables are available
- Fix TERRAFORM_S3_ENDPOINT not being properly exported from nix environment
- Add explicit debug output to trace variable exports
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/6).
* __->__ #6
* #5
* #4