### PR TITLE
fix: Resolve Terraform configuration issues and add sitevar debug workflow

### DIFF
--- a/.github/workflows/debug-sitevar.yml
+++ b/.github/workflows/debug-sitevar.yml
@@ -1,0 +1,45 @@
+name: Debug Sitevar Sync
+
+on:
+  workflow_dispatch:
+
+jobs:
+  debug-sitevar:
+    runs-on: ubuntu-latest
+    environment: infrastructure
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: DeterminateSystems/nix-installer-action@main
+        with: { determinate: true }
+      
+      - name: Debug sitevar sync
+        run: |
+          echo "=== Testing Sitevar Sync ==="
+          nix develop --accept-flake-config --command bash -c "
+            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
+            
+            echo '🔍 Listing available sitevars...'
+            bft sitevar list || echo 'Failed to list sitevars'
+            
+            echo ''
+            echo '🔍 Checking for TERRAFORM variables...'
+            bft sitevar list | grep -i terraform || echo 'No TERRAFORM variables found'
+            
+            echo ''
+            echo '🔍 Checking for backend/endpoint variables...'
+            bft sitevar list | grep -i -E '(backend|endpoint|s3)' || echo 'No backend/endpoint variables found'
+            
+            echo ''
+            echo '📥 Running sync...'
+            bft sitevar sync --force
+            
+            echo ''
+            echo '📋 Checking .env.secrets content (variable names only)...'
+            if [ -f .env.secrets ]; then
+              grep '^[A-Z]' .env.secrets | cut -d= -f1 | sort | grep -E '(TERRAFORM|AWS|S3|BACKEND|ENDPOINT)' || echo 'No matching variables'
+            else
+              echo '.env.secrets not created!'
+            fi
+          "

--- a/infra/terraform/hetzner/github.tf
+++ b/infra/terraform/hetzner/github.tf
@@ -1,23 +1,7 @@
 # GitHub Repository Configuration
-terraform {
-  required_providers {
-    github = {
-      source  = "integrations/github"
-      version = "~> 6.2"  # Rulesets require 6.2+
-    }
-  }
-}
+# Note: terraform block and providers are defined in main.tf
 
-variable "github_token" {
-  description = "GitHub Personal Access Token with repo permissions"
-  type        = string
-  sensitive   = true
-}
-
-variable "github_username" {
-  description = "GitHub username/organization"
-  type        = string
-}
+# Variables are already defined in main.tf
 
 provider "github" {
   token = var.github_token

--- a/infra/terraform/hetzner/main.tf
+++ b/infra/terraform/hetzner/main.tf
@@ -15,6 +15,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.2"  # Rulesets require 6.2+
+    }
   }
   
   # Backend uses CI project for state storage in Helsinki
@@ -52,6 +56,12 @@ variable "cloudflare_zone_id" {
 variable "github_username" {
   description = "GitHub username for container registry"
   type        = string
+}
+
+variable "github_token" {
+  description = "GitHub Personal Access Token with repo permissions"
+  type        = string
+  sensitive   = true
 }
 
 


### PR DESCRIPTION

- Fix duplicate terraform providers and variables between main.tf and github.tf
- Add github provider to main.tf required_providers
- Add missing github_token variable to main.tf
- Add debug workflow to investigate missing TERRAFORM_BACKEND_ENDPOINT variable
- The empty TERRAFORM_S3_ENDPOINT is likely due to missing sitevar in 1Password
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/7).
* __->__ #7
* #6
* #5
* #4