### PR TITLE
fix: Use S3_ENDPOINT as fallback for TERRAFORM_BACKEND_ENDPOINT

### DIFF
--- a/.github/actions/debug-terraform-env/action.yml
+++ b/.github/actions/debug-terraform-env/action.yml
@@ -67,10 +67,12 @@ runs:
           # Debug: Show what we're about to export
           echo ''
           echo '📋 Variables to export:'
-          echo \"TERRAFORM_S3_ENDPOINT=\$TERRAFORM_BACKEND_ENDPOINT\"
+          # Use S3_ENDPOINT as fallback if TERRAFORM_BACKEND_ENDPOINT is not set
+          ENDPOINT_TO_USE=\${TERRAFORM_BACKEND_ENDPOINT:-\$S3_ENDPOINT}
+          echo \"TERRAFORM_S3_ENDPOINT=\$ENDPOINT_TO_USE\"
           
           # Export to GitHub env - need to escape properly
-          echo \"TERRAFORM_S3_ENDPOINT=\$TERRAFORM_BACKEND_ENDPOINT\" >> \$GITHUB_ENV
+          echo \"TERRAFORM_S3_ENDPOINT=\$ENDPOINT_TO_USE\" >> \$GITHUB_ENV
           echo \"AWS_ACCESS_KEY_ID=\$TERRAFORM_BACKEND_ACCESS_KEY_ID\" >> \$GITHUB_ENV
           echo \"AWS_SECRET_ACCESS_KEY=\$TERRAFORM_BACKEND_SECRET_ACCESS_KEY\" >> \$GITHUB_ENV
 

--- a/.github/actions/setup-terraform-env/action.yml
+++ b/.github/actions/setup-terraform-env/action.yml
@@ -46,7 +46,8 @@ runs:
           # CI project credentials for Terraform backend
           export AWS_ACCESS_KEY_ID=\$TERRAFORM_BACKEND_ACCESS_KEY_ID
           export AWS_SECRET_ACCESS_KEY=\$TERRAFORM_BACKEND_SECRET_ACCESS_KEY
-          export TERRAFORM_S3_ENDPOINT=\$TERRAFORM_BACKEND_ENDPOINT
+          # Use S3_ENDPOINT if TERRAFORM_BACKEND_ENDPOINT is not set
+          export TERRAFORM_S3_ENDPOINT=\${TERRAFORM_BACKEND_ENDPOINT:-\$S3_ENDPOINT}
 
           # Save to GitHub env for subsequent steps
           echo \"TF_VAR_hcloud_token=\$TF_VAR_hcloud_token\" >> \$GITHUB_ENV

--- a/.github/workflows/debug-sitevar.yml
+++ b/.github/workflows/debug-sitevar.yml
@@ -38,6 +38,10 @@ jobs:
             echo ''
             echo '📋 Checking .env.secrets content (variable names only)...'
             if [ -f .env.secrets ]; then
+              echo '=== ALL variables in .env.secrets ==='
+              grep '^[A-Z]' .env.secrets | cut -d= -f1 | sort
+              echo ''
+              echo '=== Filtered for Terraform/Backend/S3 ==='
               grep '^[A-Z]' .env.secrets | cut -d= -f1 | sort | grep -E '(TERRAFORM|AWS|S3|BACKEND|ENDPOINT)' || echo 'No matching variables'
             else
               echo '.env.secrets not created!'


### PR DESCRIPTION

- Update setup-terraform-env to use S3_ENDPOINT if TERRAFORM_BACKEND_ENDPOINT is not set
- Update debug-terraform-env with the same fallback logic
- Update debug-sitevar workflow to show all variables in .env.secrets
- This should resolve the empty TERRAFORM_S3_ENDPOINT issue
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/8).
* __->__ #8
* #7
* #6
* #5
* #4