### PR TITLE
Add /internalbf/bin to PATH in container for ibft access

### DIFF
--- a/infra/Dockerfile.infra
+++ b/infra/Dockerfile.infra
@@ -274,7 +274,7 @@ if [ -f "/internalbf/bfmono/.env.secrets" ]; then
 fi
 
 # Add Nix and BF_ROOT to PATH
-export PATH="/internalbf/bfmono/infra/bin:/nix/var/nix/profiles/default/bin:\$PATH"
+export PATH="/internalbf/bin:/internalbf/bfmono/infra/bin:/nix/var/nix/profiles/default/bin:\$PATH"
 
 # Set Puppeteer executable path for e2e tests (use Chrome/Chromium based on what's available)
 if [ -x "/usr/bin/google-chrome-stable" ]; then


### PR DESCRIPTION

- Updated Dockerfile.infra to include /internalbf/bin in PATH
- This makes ibft command available in containers
- Also includes minor formatting fix in generate-kamal-config.bft.ts

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
