### PR TITLE
URGENT: Fix security issue - mask AWS credentials in workflow output

### DIFF
--- a/.github/workflows/infrastructure-hetzner-debug.yml
+++ b/.github/workflows/infrastructure-hetzner-debug.yml
@@ -64,10 +64,10 @@ jobs:
           echo "S3 Endpoint: ${TERRAFORM_S3_ENDPOINT:-NOT SET}"
           echo "AWS Access Key ID present: $([[ -n "$AWS_ACCESS_KEY_ID" ]] && echo "Yes" || echo "No")"
           
-          # Debug: List all environment variables starting with TERRAFORM or AWS
+          # Debug: List environment variables (masking sensitive values)
           echo ""
-          echo "=== Terraform/AWS Environment Variables ==="
-          env | grep -E '^(TERRAFORM|AWS)' | grep -v SECRET | sort || echo "No TERRAFORM/AWS vars found"
+          echo "=== Terraform/AWS Environment Variables (masked) ==="
+          env | grep -E '^(TERRAFORM|AWS)' | sed 's/=.*/=***MASKED***/' | sort || echo "No TERRAFORM/AWS vars found"
           
           # Check if endpoint is in env context
           echo ""


### PR DESCRIPTION

- The debug workflow was exposing AWS credentials in public logs
- Changed env output to mask sensitive values
- AWS credentials need to be rotated immediately
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/10).
* #11
* __->__ #10
* #8
* #7
* #6
* #5
* #4