### PR TITLE
feat: Add workflow to create PRs for repository file updates

### DIFF
--- a/.github/workflows/update-repository-files.yml
+++ b/.github/workflows/update-repository-files.yml
@@ -1,0 +1,72 @@
+name: Update Repository Files
+
+on:
+  workflow_dispatch:
+    inputs:
+      file_path:
+        description: 'Path to the file to update'
+        required: true
+        type: string
+      file_content:
+        description: 'Base64 encoded content of the file'
+        required: true
+        type: string
+      commit_message:
+        description: 'Commit message'
+        required: false
+        type: string
+        default: 'Update repository file via automation'
+
+jobs:
+  update-file:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create branch
+        run: |
+          BRANCH_NAME="update-file-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b $BRANCH_NAME
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Update file
+        run: |
+          # Decode base64 content and write to file
+          echo "${{ inputs.file_content }}" | base64 -d > "${{ inputs.file_path }}"
+          
+          # Create directory if it doesn't exist
+          mkdir -p "$(dirname "${{ inputs.file_path }}")"
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "${{ inputs.file_path }}"
+          git commit -m "${{ inputs.commit_message }}"
+
+      - name: Push branch
+        run: |
+          git push origin $BRANCH_NAME
+
+      - name: Create Pull Request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '${{ inputs.commit_message }}',
+              body: `This PR was automatically generated to update \`${{ inputs.file_path }}\`.
+              
+              The file was updated via the Update Repository Files workflow.`,
+              head: process.env.BRANCH_NAME,
+              base: 'main'
+            });
+            
+            console.log(`Created PR #${pr.data.number}: ${pr.data.html_url}`);
+            
+            // Set output for other workflows
+            core.setOutput('pr_number', pr.data.number);
+            core.setOutput('pr_url', pr.data.html_url);

--- a/infra/terraform/hetzner/github.tf
+++ b/infra/terraform/hetzner/github.tf
@@ -169,22 +169,9 @@ resource "github_actions_repository_permissions" "bfmono" {
 }
 
 # Configure Actions permissions
-resource "github_repository_file" "actions_permissions" {
-  repository = github_repository.bfmono.name
-  file       = ".github/actions-permissions.yml"
-  content    = yamlencode({
-    permissions = {
-      contents = "write"
-      pull-requests = "write"
-      issues = "write"
-      actions = "write"
-    }
-  })
-  
-  lifecycle {
-    ignore_changes = [content]  # Don't overwrite if manually edited
-  }
-}
+# Note: Removed github_repository_file resource because it violates branch protection rules
+# that require all changes to go through pull requests with status checks and signed commits.
+# Actions permissions should be configured through the GitHub UI or via pull requests.
 
 # Outputs
 output "repository_url" {

--- a/infra/terraform/hetzner/github.tf
+++ b/infra/terraform/hetzner/github.tf
@@ -168,10 +168,48 @@ resource "github_actions_repository_permissions" "bfmono" {
   allowed_actions = "all"
 }
 
-# Configure Actions permissions
-# Note: Removed github_repository_file resource because it violates branch protection rules
-# that require all changes to go through pull requests with status checks and signed commits.
-# Actions permissions should be configured through the GitHub UI or via pull requests.
+# Configure Actions permissions file through workflow
+# This triggers a workflow that creates a PR with the file changes,
+# respecting branch protection rules
+resource "null_resource" "actions_permissions_pr" {
+  triggers = {
+    content_hash = sha256(jsonencode({
+      permissions = {
+        contents      = "write"
+        pull-requests = "write"
+        issues        = "write"
+        actions       = "write"
+      }
+    }))
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      # Encode the content as base64
+      CONTENT=$(echo '${jsonencode({
+        permissions = {
+          contents      = "write"
+          pull-requests = "write"
+          issues        = "write"
+          actions       = "write"
+        }
+      })}' | base64 -w 0)
+      
+      # Trigger the workflow
+      gh workflow run update-repository-files.yml \
+        --repo ${var.github_username}/${github_repository.bfmono.name} \
+        --field file_path=".github/actions-permissions.yml" \
+        --field file_content="$CONTENT" \
+        --field commit_message="Update GitHub Actions permissions"
+    EOT
+    
+    environment = {
+      GITHUB_TOKEN = var.github_token
+    }
+  }
+  
+  depends_on = [github_repository.bfmono]
+}
 
 # Outputs
 output "repository_url" {


### PR DESCRIPTION

- Created update-repository-files.yml workflow that creates PRs
- Updated Terraform to use this workflow instead of github_repository_file
- This respects branch protection rules by creating PRs instead of direct pushes
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/17).
* #18
* __->__ #17
* #16