### PR TITLE
Remove HUD debugging calls from eval pipeline and update login flow

### DIFF
--- a/apps/boltfoundry-com/components/Eval.tsx
+++ b/apps/boltfoundry-com/components/Eval.tsx
@@ -1,32 +1,13 @@
 import { iso } from "@iso-bfc";
-import { EvalProvider, useEvalContext } from "../contexts/EvalContext.tsx";
+import { useEffect } from "react";
+import { EvalProvider } from "../contexts/EvalContext.tsx";
 import { Header } from "./Evals/Layout/Header.tsx";
 import { LeftSidebar } from "./Evals/Layout/LeftSidebar.tsx";
 import { MainContent } from "./Evals/Layout/MainContent.tsx";
 import { RightSidebar } from "./Evals/Layout/RightSidebar.tsx";
 import { useHud } from "@bfmono/apps/bfDs/contexts/BfDsHudContext.tsx";
-import { useEffect } from "react";
 
 function EvalContent() {
-  const evalContext = useEvalContext();
-  const { addButton, removeButton, sendMessage } = useHud();
-
-  useEffect(() => {
-    // Add button to show eval context state
-    addButton({
-      id: "show-eval-state",
-      label: "Show Eval State",
-      onClick: () => {
-        sendMessage(JSON.stringify(evalContext, null, 2), "info");
-      },
-      icon: "info",
-    });
-
-    // Cleanup buttons on unmount
-    return () => {
-      removeButton("show-eval-state");
-    };
-  }, [evalContext, addButton, removeButton, sendMessage]);
   return (
     <div className="eval-page">
       <Header />
@@ -67,30 +48,12 @@ export const Eval = iso(`
     }
   }
 `)(function Eval({ data }) {
-  const { sendMessage } = useHud();
+  const { sendMessage, showHud } = useHud();
 
   useEffect(() => {
-    sendMessage("Eval component data:", "info");
-    sendMessage(JSON.stringify(data, null, 2), "info");
-
-    // Log deck data specifically
-    if (data?.currentViewer?.asCurrentViewerLoggedIn?.organization?.decks) {
-      sendMessage("Decks found:", "success");
-      const decks =
-        data.currentViewer.asCurrentViewerLoggedIn.organization.decks;
-      sendMessage(`Total deck edges: ${decks.edges?.length || 0}`, "info");
-      decks.edges?.forEach((edge, index) => {
-        if (edge && edge.node) {
-          sendMessage(
-            `Deck ${index + 1}: ${edge.node.name} (${edge.node.id})`,
-            "info",
-          );
-        }
-      });
-    } else {
-      sendMessage("No decks found in GraphQL response", "warning");
-    }
-  }, [data, sendMessage]);
+    showHud();
+    sendMessage(`Isograph data:\n${JSON.stringify(data, null, 2)}`, "info");
+  }, []);
 
   return (
     <EvalProvider>

--- a/apps/boltfoundry-com/components/Evals/Decks/DeckList.tsx
+++ b/apps/boltfoundry-com/components/Evals/Decks/DeckList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { BfDsButton } from "@bfmono/apps/bfDs/components/BfDsButton.tsx";
 import { BfDsEmptyState } from "@bfmono/apps/bfDs/components/BfDsEmptyState.tsx";
 import { BfDsInput } from "@bfmono/apps/bfDs/components/BfDsInput.tsx";
@@ -6,7 +6,6 @@ import { DeckItem } from "./DeckItem.tsx";
 import { DeckCreateModal, type DeckFormData } from "./DeckCreateModal.tsx";
 import { useEvalContext } from "@bfmono/apps/boltfoundry-com/contexts/EvalContext.tsx";
 import { getLogger } from "@bfmono/packages/logger/logger.ts";
-import { useHud } from "@bfmono/apps/bfDs/contexts/BfDsHudContext.tsx";
 
 const logger = getLogger(import.meta);
 
@@ -52,19 +51,9 @@ interface DeckListProps {
 
 export function DeckList({ onDeckSelect }: DeckListProps) {
   const { startDeckCreation, startGrading } = useEvalContext();
-  const { sendMessage, showHud } = useHud();
   const [searchQuery, setSearchQuery] = useState("");
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [decks] = useState(mockDecks);
-
-  useEffect(() => {
-    showHud();
-    sendMessage("DeckList mounted - using mock data", "info");
-    sendMessage(
-      `Mock decks loaded: ${mockDecks.map((d) => d.name).join(", ")}`,
-      "info",
-    );
-  }, [sendMessage, showHud]);
 
   const filteredDecks = decks.filter((deck) =>
     deck.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -80,8 +69,6 @@ export function DeckList({ onDeckSelect }: DeckListProps) {
   const handleDeckClick = (deckId: string) => {
     const deck = decks.find((d) => d.id === deckId);
     if (deck) {
-      sendMessage(`Deck selected: ${deck.name} (ID: ${deckId})`, "info");
-      sendMessage(`Starting grading session for deck: ${deck.name}`, "info");
       // Samples will be fetched by GradingInbox using GraphQL
       startGrading(deckId, deck.name);
     }

--- a/apps/boltfoundry-com/components/Evals/Grading/GradingInbox.tsx
+++ b/apps/boltfoundry-com/components/Evals/Grading/GradingInbox.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { BfDsButton } from "@bfmono/apps/bfDs/components/BfDsButton.tsx";
 import { BfDsIcon } from "@bfmono/apps/bfDs/components/BfDsIcon.tsx";
 import { BfDsSpinner } from "@bfmono/apps/bfDs/components/BfDsSpinner.tsx";
 import { SampleDisplay } from "./SampleDisplay.tsx";
 import { useGradingSamples } from "@bfmono/apps/boltfoundry-com/hooks/useGradingSamples.ts";
 import { getLogger } from "@bfmono/packages/logger/logger.ts";
-import { useHud } from "@bfmono/apps/bfDs/contexts/BfDsHudContext.tsx";
 
 const logger = getLogger(import.meta);
 
@@ -22,7 +21,6 @@ export function GradingInbox({
   onClose,
   onComplete,
 }: GradingInboxProps) {
-  const { sendMessage } = useHud();
   const [currentIndex, setCurrentIndex] = useState(0);
   const [completedCount, setCompletedCount] = useState(0);
   const [gradedSampleIds, setGradedSampleIds] = useState<Array<string>>([]);
@@ -41,20 +39,6 @@ export function GradingInbox({
   const { samples, loading, error, saveGrade, saving } = useGradingSamples(
     deckId,
   );
-
-  useEffect(() => {
-    sendMessage(
-      `GradingInbox mounted for deck: ${deckName} (ID: ${deckId})`,
-      "info",
-    );
-  }, [deckId, deckName, sendMessage]);
-
-  useEffect(() => {
-    if (samples) {
-      sendMessage(`Samples loaded: ${samples.length} samples`, "success");
-      sendMessage(`Sample IDs: ${samples.map((s) => s.id).join(", ")}`, "info");
-    }
-  }, [samples, sendMessage]);
 
   // Handle loading and error states
   if (loading) {

--- a/apps/boltfoundry-com/components/LoginWithGoogleButton.tsx
+++ b/apps/boltfoundry-com/components/LoginWithGoogleButton.tsx
@@ -39,7 +39,8 @@ export function LoginWithGoogleButton() {
   const [error, setError] = useState<string | null>(null);
   const [forceRealButton, setForceRealButton] = useState(false);
   const appEnvironment = useAppEnvironment();
-  const { input1, setInput1, addButton, removeButton, sendMessage } = useHud();
+  const { input1, setInput1, addButton, removeButton, sendMessage, showHud } =
+    useHud();
 
   const googleButtonRef = useRef<HTMLDivElement>(null);
   const callbackRef = useRef<
@@ -211,6 +212,10 @@ export function LoginWithGoogleButton() {
       hasCredential: !!response.credential,
     });
 
+    // Show HUD with logging in message
+    showHud();
+    sendMessage("Logging in...", "info");
+
     try {
       // Send credential to backend for verification and session creation
       const loginResponse = await fetch("/api/auth/google", {
@@ -229,7 +234,8 @@ export function LoginWithGoogleButton() {
       logger.info("Login successful", result);
 
       // Redirect to the specified location from the server response
-      globalThis.location.href = result.redirectTo || "/";
+      // Temporarily disabled redirect to /eval
+      // globalThis.location.href = "/";
     } catch (err) {
       setIsLoading(false);
       setError("Failed to sign in with Google. Please try again.");

--- a/infra/bft/tasks/generate-kamal-config.bft.ts
+++ b/infra/bft/tasks/generate-kamal-config.bft.ts
@@ -59,7 +59,7 @@ async function generateKamalConfig(args: Array<string>): Promise<number> {
     interface KamalConfig {
       env?: {
         clear?: Record<string, unknown>;
-        secret?: string[];
+        secret?: Array<string>;
       };
       [key: string]: unknown;
     }


### PR DESCRIPTION

- Remove HUD-related useEffects and logging from Eval.tsx
- Remove HUD usage from DeckList.tsx (removed mock data logging)
- Remove HUD usage from GradingInbox.tsx (removed mount/sample logging)
- Add single HUD message for Isograph data in Eval.tsx for debugging
- Disable redirect after login, show HUD with "Logging in..." instead

These changes clean up the eval pipeline while preserving HUD functionality
in the navigation bar and adding minimal debugging for login/data inspection.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
