### PR TITLE
Add HTTPS support to codebot and improve container management

### DIFF
--- a/infra/Dockerfile.infra
+++ b/infra/Dockerfile.infra
@@ -160,14 +160,23 @@ if [ $# -eq 0 ] || [ "$1" = "-l" ]; then\n\
         cd /internalbf/bfmono && deno run --allow-net --allow-run --allow-env --allow-read infra/apps/codebot/container-bridge.ts > /tmp/container-bridge.log 2>&1 &\n\
         echo "Container bridge started in background (PID: $!)"\n\
     fi\n\
+    \n\
+    # Start HTTPS proxy if certificate exists\n\
+    if [ -f "/internalbf/bfmono/shared/certs/codebot-wildcard.pem" ] && [ -f "/internalbf/bfmono/infra/apps/codebot/https-proxy-server.ts" ]; then\n\
+        # Grant deno capability to bind to privileged ports\n\
+        sudo setcap cap_net_bind_service=+ep $(which deno)\n\
+        # Start HTTPS proxy in background\n\
+        cd /internalbf/bfmono && deno run --allow-net --allow-read --allow-write infra/apps/codebot/https-proxy-server.ts > /tmp/https-proxy.log 2>&1 &\n\
+        echo "HTTPS proxy started in background (PID: $!)"\n\
+    fi\n\
 fi\n\
 \n\
 # Execute bash with login shell\n\
 exec /bin/bash -l "$@"\n' > /usr/local/bin/docker-entrypoint.sh && \
     chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Configure sudo for codebot user to allow /etc/hosts management without password
-RUN echo "codebot ALL=(ALL) NOPASSWD: /bin/cp * /etc/hosts, /usr/bin/tee /etc/hosts, /usr/bin/tee -a /etc/hosts" >> /etc/sudoers.d/codebot && \
+# Configure sudo for codebot user to allow /etc/hosts management and setcap without password
+RUN echo "codebot ALL=(ALL) NOPASSWD: /bin/cp * /etc/hosts, /usr/bin/tee /etc/hosts, /usr/bin/tee -a /etc/hosts, /usr/sbin/setcap cap_net_bind_service=+ep /usr/bin/deno, /usr/sbin/setcap cap_net_bind_service=+ep /nix/*/bin/deno" >> /etc/sudoers.d/codebot && \
     chmod 0440 /etc/sudoers.d/codebot
 
 # Create non-root user (Debian uses useradd)

--- a/infra/apps/codebot/cert-utils.ts
+++ b/infra/apps/codebot/cert-utils.ts
@@ -1,0 +1,180 @@
+import { exists } from "@std/fs";
+import { getLogger } from "@bolt-foundry/logger";
+
+const logger = getLogger(import.meta);
+
+export async function generateWildcardCert(
+  certPath: string,
+  keyPath: string,
+): Promise<void> {
+  logger.info(
+    "Generating self-signed wildcard certificate for *.codebot.local",
+  );
+
+  // Create OpenSSL config for wildcard certificate
+  const opensslConfig = `
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+CN = *.codebot.local
+
+[v3_req]
+keyUsage = keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = *.codebot.local
+DNS.2 = codebot.local
+`;
+
+  // Write temporary config file
+  const configPath = "/tmp/codebot-openssl.cnf";
+  await Deno.writeTextFile(configPath, opensslConfig);
+
+  try {
+    // Generate private key and certificate in one command
+    const command = new Deno.Command("openssl", {
+      args: [
+        "req",
+        "-x509",
+        "-nodes",
+        "-days",
+        "365",
+        "-newkey",
+        "rsa:2048",
+        "-keyout",
+        keyPath,
+        "-out",
+        certPath,
+        "-config",
+        configPath,
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const output = await command.output();
+
+    if (!output.success) {
+      const stderr = new TextDecoder().decode(output.stderr);
+      throw new Error(`Failed to generate certificate: ${stderr}`);
+    }
+
+    logger.info(`Certificate generated at: ${certPath}`);
+    logger.info(`Private key generated at: ${keyPath}`);
+  } finally {
+    // Clean up temp config file
+    try {
+      await Deno.remove(configPath);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+export async function trustCertificate(certPath: string): Promise<void> {
+  logger.info("Adding certificate to system trust store...");
+
+  if (Deno.build.os === "darwin") {
+    // macOS: Add to system keychain and trust
+    logger.info("Detected macOS - adding certificate to system keychain");
+
+    const command = new Deno.Command("sudo", {
+      args: [
+        "security",
+        "add-trusted-cert",
+        "-d",
+        "-r",
+        "trustRoot",
+        "-k",
+        "/Library/Keychains/System.keychain",
+        certPath,
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const output = await command.output();
+
+    if (!output.success) {
+      const stderr = new TextDecoder().decode(output.stderr);
+      logger.warn(`Failed to trust certificate: ${stderr}`);
+      logger.info(
+        "You may need to manually trust the certificate in Keychain Access",
+      );
+    } else {
+      logger.info("Certificate successfully added to system trust store");
+    }
+  } else if (Deno.build.os === "linux") {
+    // Linux: Copy to system trust store
+    logger.info("Detected Linux - adding certificate to ca-certificates");
+
+    // First copy the certificate
+    const copyCommand = new Deno.Command("sudo", {
+      args: [
+        "cp",
+        certPath,
+        "/usr/local/share/ca-certificates/codebot-wildcard.crt",
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const copyOutput = await copyCommand.output();
+
+    if (!copyOutput.success) {
+      const stderr = new TextDecoder().decode(copyOutput.stderr);
+      logger.warn(`Failed to copy certificate: ${stderr}`);
+      logger.info("You may need to manually trust the certificate");
+      return;
+    }
+
+    // Update CA certificates
+    const updateCommand = new Deno.Command("sudo", {
+      args: ["update-ca-certificates"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const updateOutput = await updateCommand.output();
+
+    if (!updateOutput.success) {
+      const stderr = new TextDecoder().decode(updateOutput.stderr);
+      logger.warn(`Failed to update ca-certificates: ${stderr}`);
+    } else {
+      logger.info("Certificate successfully added to system trust store");
+    }
+  } else {
+    logger.warn(`Unsupported OS: ${Deno.build.os}`);
+    logger.info("Please manually trust the certificate at:", certPath);
+  }
+
+  logger.info(
+    "You may need to restart your browser for the certificate to be recognized",
+  );
+}
+
+export async function ensureWildcardCertificate(
+  sharedCertDir: string,
+): Promise<void> {
+  const wildcardCertPath = `${sharedCertDir}/codebot-wildcard.pem`;
+  const wildcardKeyPath = `${sharedCertDir}/codebot-wildcard-key.pem`;
+
+  if (!await exists(wildcardCertPath)) {
+    await Deno.mkdir(sharedCertDir, { recursive: true });
+
+    // Generate self-signed wildcard certificate for *.codebot.local
+    await generateWildcardCert(wildcardCertPath, wildcardKeyPath);
+
+    // Trust the certificate in the system keychain (on host)
+    await trustCertificate(wildcardCertPath);
+
+    logger.info("Certificate generated and trusted for HTTPS support");
+  } else {
+    logger.info("Using existing wildcard certificate");
+  }
+}

--- a/infra/apps/codebot/container-bridge.ts
+++ b/infra/apps/codebot/container-bridge.ts
@@ -39,6 +39,7 @@ export function startContainerBridge(port = 8017) {
             status: appStatus,
             healthy: appHealthy,
             url: `http://${workspaceId}.codebot.local:8000`,
+            httpsUrl: `https://${workspaceId}.codebot.local`,
           },
         },
         workspaceId,

--- a/infra/apps/codebot/https-proxy-server.ts
+++ b/infra/apps/codebot/https-proxy-server.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env -S deno run --allow-net --allow-read --allow-write
+
+import { getLogger } from "@bolt-foundry/logger";
+
+const logger = getLogger(import.meta);
+
+// Load wildcard certificate from shared folder
+const certPath = "/internalbf/bfmono/shared/certs/codebot-wildcard.pem";
+const keyPath = "/internalbf/bfmono/shared/certs/codebot-wildcard-key.pem";
+
+// Known backend routes from boltfoundry-com
+const backendRoutes = new Set([
+  // App routes
+  "/",
+  "/login",
+  "/rlhf",
+  "/eval",
+  "/plinko",
+  "/ui",
+  // API routes
+  "/health",
+  "/api/telemetry",
+  "/graphql",
+  "/api/auth/google",
+  "/api/auth/dev-popup",
+]);
+
+const backendPatterns = [
+  /^\/ui\/.*/, // /ui/* routes
+  /^\/static\/.*/, // Static assets served by backend
+];
+
+function shouldRouteToBackend(pathname: string): boolean {
+  // Check exact routes
+  if (backendRoutes.has(pathname)) return true;
+
+  // Check patterns
+  for (const pattern of backendPatterns) {
+    if (pattern.test(pathname)) return true;
+  }
+
+  return false;
+}
+
+async function startHTTPSProxy() {
+  try {
+    // Check if certificate files exist
+    try {
+      await Deno.stat(certPath);
+      await Deno.stat(keyPath);
+    } catch (error) {
+      logger.error("Certificate files not found:", error);
+      logger.error(`Expected cert at: ${certPath}`);
+      logger.error(`Expected key at: ${keyPath}`);
+      logger.error("Please run certificate generation first");
+      Deno.exit(1);
+    }
+
+    // Read certificate and key
+    const cert = await Deno.readTextFile(certPath);
+    const key = await Deno.readTextFile(keyPath);
+
+    logger.info("Starting HTTPS proxy server on port 443...");
+
+    // HTTPS proxy server
+    const httpsServer = Deno.serve({
+      port: 443,
+      cert,
+      key,
+      hostname: "0.0.0.0",
+      handler: async (req) => {
+        const url = new URL(req.url);
+        const targetPort = shouldRouteToBackend(url.pathname) ? 8000 : 8080;
+
+        logger.info(
+          `HTTPS ${req.method} ${url.pathname} → localhost:${targetPort}`,
+        );
+
+        // Proxy to the appropriate service
+        const targetUrl = new URL(url);
+        targetUrl.protocol = "http:";
+        targetUrl.hostname = "localhost";
+        targetUrl.port = String(targetPort);
+
+        try {
+          const response = await fetch(targetUrl, {
+            method: req.method,
+            headers: req.headers,
+            body: req.body,
+          });
+
+          // Create new headers to avoid immutable headers issue
+          const headers = new Headers();
+          response.headers.forEach((value, key) => {
+            // Skip hop-by-hop headers
+            if (
+              !["connection", "keep-alive", "transfer-encoding"].includes(
+                key.toLowerCase(),
+              )
+            ) {
+              headers.set(key, value);
+            }
+          });
+
+          return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers,
+          });
+        } catch (error) {
+          logger.error(`Failed to proxy request: ${error}`);
+          return new Response("Bad Gateway", { status: 502 });
+        }
+      },
+      onListen: ({ hostname, port }) => {
+        logger.info(`HTTPS server listening on https://${hostname}:${port}`);
+      },
+    });
+
+    logger.info("Starting HTTP redirect server on port 80...");
+
+    // HTTP redirect server
+    const httpServer = Deno.serve({
+      port: 80,
+      hostname: "0.0.0.0",
+      handler: (req) => {
+        const url = new URL(req.url);
+        const httpsUrl = `https://${url.host}${url.pathname}${url.search}`;
+
+        logger.info(
+          `HTTP ${req.method} ${url.pathname} → redirect to ${httpsUrl}`,
+        );
+
+        return Response.redirect(httpsUrl, 301);
+      },
+      onListen: ({ hostname, port }) => {
+        logger.info(
+          `HTTP redirect server listening on http://${hostname}:${port}`,
+        );
+      },
+    });
+
+    // Wait for both servers
+    await Promise.all([httpsServer.finished, httpServer.finished]);
+  } catch (error) {
+    logger.error("Failed to start proxy server:", error);
+    Deno.exit(1);
+  }
+}
+
+// Handle graceful shutdown
+const shutdown = () => {
+  logger.info("Shutting down proxy servers...");
+  Deno.exit(0);
+};
+
+Deno.addSignalListener("SIGINT", shutdown);
+Deno.addSignalListener("SIGTERM", shutdown);
+
+// Start the proxy
+await startHTTPSProxy();

--- a/infra/bft/tasks/codebot.bft.ts
+++ b/infra/bft/tasks/codebot.bft.ts
@@ -56,7 +56,8 @@ WORKSPACE INFO:
 
 DEBUGGING:
   - Container name matches workspace name
-  - Access via: http://<workspace-name>.codebot.local:8000
+  - Access via: https://<workspace-name>.codebot.local
+  - Legacy HTTP: http://<workspace-name>.codebot.local:8000
   - Shell access: bft codebot --workspace <name> --shell
   - View logs: container logs <workspace-name>
 `,

--- a/memos/2-areas/development/codebot-https-implementation.md
+++ b/memos/2-areas/development/codebot-https-implementation.md
@@ -20,6 +20,17 @@ accessed via `https://<workspace-name>.codebot.local` URLs.
 
 ## Implementation Plan
 
+### Confirmed Architecture
+
+Based on discussion:
+
+- HTTPS proxy listens on port 443 inside container (host already maps this)
+- HTTP server on port 80 redirects to HTTPS
+- Proxy routes requests:
+  - Vite dev server assets/HMR → port 8080 (or 5173)
+  - API/pages → backend server port 8000
+- No additional port mapping needed on host
+
 ### 1. Container Privilege Setup
 
 Since authbind is not available in nixpkgs, use `setcap` (the NixOS-preferred
@@ -33,26 +44,64 @@ RUN echo "codebot ALL=(ALL) NOPASSWD: /bin/cp * /etc/hosts, /usr/bin/tee /etc/ho
 
 ### 2. Certificate Management
 
-Create a local CA and dynamic certificate generation system:
+Create a wildcard certificate for `*.codebot.local`:
 
 ```typescript
-// In container-bot-base.ts
-async function ensureCertificates(): Promise<void> {
-  const certDir = `${homeDir}/.codebot/certs`;
-  const caCertPath = `${certDir}/ca.pem`;
-  const caKeyPath = `${certDir}/ca-key.pem`;
+// In container-bot-base.ts (runs on host)
+async function ensureWildcardCertificate(): Promise<void> {
+  // Store certificates in shared folder for host-container communication
+  const sharedCertDir = `${homeDir}/internalbf/bfmono/shared/certs`;
+  const wildcardCertPath = `${sharedCertDir}/codebot-wildcard.pem`;
+  const wildcardKeyPath = `${sharedCertDir}/codebot-wildcard-key.pem`;
 
-  if (!await exists(caCertPath)) {
-    await Deno.mkdir(certDir, { recursive: true });
+  if (!await exists(wildcardCertPath)) {
+    await Deno.mkdir(sharedCertDir, { recursive: true });
 
-    // Generate self-signed CA
-    await generateCA(caCertPath, caKeyPath);
+    // Generate self-signed wildcard certificate for *.codebot.local
+    await generateWildcardCert(wildcardCertPath, wildcardKeyPath);
 
-    // Install CA in system trust store
-    if (Deno.build.os === "darwin") {
-      await installCertMacOS(caCertPath);
-    }
+    // Trust the certificate in the system keychain (on host)
+    await trustCertificate(wildcardCertPath);
+
+    console.log("Certificate generated and trusted for HTTPS support");
   }
+}
+
+async function trustCertificate(certPath: string): Promise<void> {
+  if (Deno.build.os === "darwin") {
+    // macOS: Add to system keychain and trust
+    const command = new Deno.Command("sudo", {
+      args: [
+        "security",
+        "add-trusted-cert",
+        "-d",
+        "-r",
+        "trustRoot",
+        "-k",
+        "/Library/Keychains/System.keychain",
+        certPath,
+      ],
+    });
+    await command.output();
+  } else if (Deno.build.os === "linux") {
+    // Linux: Copy to system trust store
+    const command = new Deno.Command("sudo", {
+      args: [
+        "cp",
+        certPath,
+        "/usr/local/share/ca-certificates/codebot-wildcard.crt",
+      ],
+    });
+    await command.output();
+
+    // Update CA certificates
+    const updateCommand = new Deno.Command("sudo", {
+      args: ["update-ca-certificates"],
+    });
+    await updateCommand.output();
+  }
+
+  console.log("Certificate trusted. You may need to restart your browser.");
 }
 ```
 
@@ -61,26 +110,81 @@ async function ensureCertificates(): Promise<void> {
 Create `https-proxy-server.ts` that:
 
 - Listens on ports 80/443 inside the container
-- Dynamically generates certificates for each workspace
+- Uses the wildcard certificate for all requests
 - Proxies requests to the appropriate services
 
 ```typescript
-// apps/codebot/https-proxy-server.ts
+// infra/apps/codebot/https-proxy-server.ts (runs inside container)
 import { serveTls } from "@std/http/server";
 
-const proxy = Deno.serve({
+// Load wildcard certificate from shared folder
+const certPath = "/internalbf/bfmono/shared/certs/codebot-wildcard.pem";
+const keyPath = "/internalbf/bfmono/shared/certs/codebot-wildcard-key.pem";
+
+// Known backend routes from boltfoundry-com
+const backendRoutes = new Set([
+  // App routes
+  "/",
+  "/login",
+  "/rlhf",
+  "/eval",
+  "/plinko",
+  "/ui",
+  // API routes
+  "/health",
+  "/api/telemetry",
+  "/graphql",
+  "/api/auth/google",
+  "/api/auth/dev-popup",
+]);
+
+const backendPatterns = [
+  /^\/ui\/.*/, // /ui/* routes
+  /^\/static\/.*/, // Static assets served by backend
+];
+
+function shouldRouteToBackend(pathname: string): boolean {
+  // Check exact routes
+  if (backendRoutes.has(pathname)) return true;
+
+  // Check patterns
+  for (const pattern of backendPatterns) {
+    if (pattern.test(pathname)) return true;
+  }
+
+  return false;
+}
+
+const httpsProxy = Deno.serve({
   port: 443,
   cert: await Deno.readTextFile(certPath),
   key: await Deno.readTextFile(keyPath),
   handler: async (req) => {
-    const hostname = new URL(req.url).hostname;
-    const workspace = hostname.replace(".codebot.local", "");
+    const url = new URL(req.url);
+    const targetPort = shouldRouteToBackend(url.pathname) ? 8000 : 8080;
 
-    // Get or generate certificate for this workspace
-    const { cert, key } = await getOrGenerateCert(workspace);
+    // Proxy to the appropriate service
+    const targetUrl = new URL(url);
+    targetUrl.protocol = "http:";
+    targetUrl.port = String(targetPort);
 
-    // Proxy to appropriate service
-    return await proxyRequest(req, workspace);
+    return await fetch(targetUrl, {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+    });
+  },
+});
+
+// HTTP redirect server
+const httpRedirect = Deno.serve({
+  port: 80,
+  handler: (req) => {
+    const url = new URL(req.url);
+    return Response.redirect(
+      `https://${url.host}${url.pathname}${url.search}`,
+      301,
+    );
   },
 });
 ```
@@ -102,21 +206,16 @@ deno run --allow-net --allow-read --allow-write \
   /internalbf/bfmono/infra/apps/codebot/https-proxy-server.ts &
 ```
 
-### 5. Port Mapping Updates
+### 5. No Port Mapping Changes Needed
 
-Update container creation to map HTTPS port:
-
-```typescript
-// In buildContainerArgs
-"-p", `${config.httpPort || 9280}:80`,
-"-p", `${config.httpsPort || 9283}:443`,
-```
+The existing codebot container setup already maps the necessary ports, so no
+changes are required to the port mapping configuration.
 
 ## Benefits
 
-1. Seamless HTTPS support without certificate warnings
+1. Simple wildcard certificate covers all workspaces
 2. No need for sudo when running servers
-3. Each workspace gets its own certificate
+3. Single certificate generation and management
 4. Compatible with existing DNS resolution
 
 ## Testing Plan


### PR DESCRIPTION

- Implement HTTPS proxy server for codebot workspaces
  - Listens on ports 80 (redirect) and 443 (HTTPS)
  - Routes requests to appropriate services (Vite vs backend)
  - Uses wildcard certificate for *.codebot.local

- Add certificate generation utilities
  - Generates self-signed wildcard certificate
  - Automatically trusts certificate on macOS/Linux
  - Stores in shared folder for container access

- Improve container startup experience
  - Remove annoying remote container registry checks
  - Auto-start container system to prevent errors
  - Smart rebuild warnings based on file timestamps
  - Skip container cleanup when using --workspace

- Update container infrastructure
  - Add setcap sudo permissions for privileged ports
  - Launch HTTPS proxy on container startup
  - Update help text to show HTTPS URLs

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/23).
* __->__ #23
* #22