### PR TITLE
feat: Auto-pull codebot container from ghcr.io if not found locally

### DIFF
--- a/.github/workflows/build-codebot-container.yml
+++ b/.github/workflows/build-codebot-container.yml
@@ -93,11 +93,26 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 15
 
+      - name: Create expected directory structure
+        run: |
+          # Create internalbf directory structure to match local development
+          mkdir -p ../internalbf
+          # Move the repository into the expected location
+          cd ..
+          mv ${{ github.event.repository.name }} internalbf/bfmono
+          # Create a symlink for GitHub Actions to still find the workspace
+          ln -s internalbf/bfmono ${{ github.event.repository.name }}
+          # Verify the structure
+          echo "Directory structure:"
+          ls -la internalbf/
+          echo "Contents of internalbf/bfmono:"
+          ls -la internalbf/bfmono/
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: ./infra/Dockerfile.infra
+          context: ../internalbf
+          file: ./internalbf/bfmono/infra/Dockerfile.infra
           push: ${{ !inputs.build_only }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/deno.lock
+++ b/deno.lock
@@ -3508,6 +3508,8 @@
     "https://deno.land/std@0.210.0/yaml/schema/mod.ts": "4472e827bab5025e92bc2eb2eeefa70ecbefc64b2799b765c69af84822efef32",
     "https://deno.land/std@0.210.0/yaml/stringify.ts": "fffc09c65c68d3d63f8159e8cbaa3f489bc20a8e55b4fbb61a8c2e9f914d1d02",
     "https://deno.land/std@0.210.0/yaml/type.ts": "65553da3da3c029b6589c6e4903f0afbea6768be8fca61580711457151f2b30f",
+    "https://deno.land/std@0.220.0/async/delay.ts": "8e1d18fe8b28ff95885e2bc54eccec1713f57f756053576d8228e6ca110793ad",
+    "https://deno.land/std@0.220.0/http/server.ts": "cc8ae0de927c3afc855466b89bf9a7a3196223f47f2723e218912c6ca3eb166c",
     "https://deno.land/x/denoflate@1.2.1/mod.ts": "f5628e44b80b3d80ed525afa2ba0f12408e3849db817d47a883b801f9ce69dd6",
     "https://deno.land/x/denoflate@1.2.1/pkg/denoflate.js": "b9f9ad9457d3f12f28b1fb35c555f57443427f74decb403113d67364e4f2caf4",
     "https://deno.land/x/denoflate@1.2.1/pkg/denoflate_bg.wasm.js": "d581956245407a2115a3d7e8d85a9641c032940a8e810acbd59ca86afd34d44d",

--- a/infra/Dockerfile.infra
+++ b/infra/Dockerfile.infra
@@ -175,8 +175,16 @@ fi\n\
 exec /bin/bash -l "$@"\n' > /usr/local/bin/docker-entrypoint.sh && \
     chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Configure sudo for codebot user to allow /etc/hosts management and setcap without password
-RUN echo "codebot ALL=(ALL) NOPASSWD: /bin/cp * /etc/hosts, /usr/bin/tee /etc/hosts, /usr/bin/tee -a /etc/hosts, /usr/sbin/setcap cap_net_bind_service=+ep /usr/bin/deno, /usr/sbin/setcap cap_net_bind_service=+ep /nix/*/bin/deno" >> /etc/sudoers.d/codebot && \
+# Configure sudo for codebot user - allow specific commands without password
+RUN echo "# Allow codebot to manage /etc/hosts" >> /etc/sudoers.d/codebot && \
+    echo "codebot ALL=(ALL) NOPASSWD: /bin/cp * /etc/hosts" >> /etc/sudoers.d/codebot && \
+    echo "codebot ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/hosts" >> /etc/sudoers.d/codebot && \
+    echo "codebot ALL=(ALL) NOPASSWD: /usr/bin/tee -a /etc/hosts" >> /etc/sudoers.d/codebot && \
+    echo "# Allow codebot to set capabilities on any file" >> /etc/sudoers.d/codebot && \
+    echo "codebot ALL=(ALL) NOPASSWD: /usr/sbin/setcap *" >> /etc/sudoers.d/codebot && \
+    echo "# Allow codebot to run HTTPS proxy with Deno from any path" >> /etc/sudoers.d/codebot && \
+    echo "codebot ALL=(ALL) NOPASSWD: /nix/store/*/bin/deno run * /internalbf/bfmono/infra/apps/codebot/https-proxy-server.ts" >> /etc/sudoers.d/codebot && \
+    echo "codebot ALL=(ALL) NOPASSWD: /usr/bin/deno run * /internalbf/bfmono/infra/apps/codebot/https-proxy-server.ts" >> /etc/sudoers.d/codebot && \
     chmod 0440 /etc/sudoers.d/codebot
 
 # Create non-root user (Debian uses useradd)

--- a/infra/Dockerfile.nix
+++ b/infra/Dockerfile.nix
@@ -40,6 +40,15 @@ RUN --mount=type=secret,id=op_token \
     else \
       echo 'No OP_SERVICE_ACCOUNT_TOKEN provided, using example env files'; \
     fi; \
+    # Ensure env files exist (use examples as fallback) \
+    if [ ! -f .env.config ]; then \
+      echo 'Creating .env.config from example...'; \
+      cp .env.config.example .env.config || echo '# Empty config' > .env.config; \
+    fi; \
+    if [ ! -f .env.secrets ]; then \
+      echo 'Creating .env.secrets from example...'; \
+      cp .env.secrets.example .env.secrets || echo '# Empty secrets' > .env.secrets; \
+    fi; \
     # Build the binary \
     echo 'Building ${BINARY_NAME}...'; \
     bft compile ${BINARY_NAME}; \
@@ -64,9 +73,12 @@ ARG BINARY_NAME=boltfoundry-com
 COPY --from=builder /workspace/build/${BINARY_NAME} /usr/local/bin/${BINARY_NAME}
 RUN chmod +x /usr/local/bin/${BINARY_NAME}
 
-# Copy environment files from builder (these were synced from 1Password)
-COPY --from=builder /workspace/.env.config /app/.env.config
-COPY --from=builder /workspace/.env.secrets /app/.env.secrets
+# Copy environment files from builder (these were synced from 1Password or created from examples)
+# Use conditional copy pattern to handle missing files gracefully
+COPY --from=builder /workspace/.env.* /tmp/
+RUN if [ -f /tmp/.env.config ]; then mv /tmp/.env.config /app/.env.config; else echo '# Empty config' > /app/.env.config; fi && \
+    if [ -f /tmp/.env.secrets ]; then mv /tmp/.env.secrets /app/.env.secrets; else echo '# Empty secrets' > /app/.env.secrets; fi && \
+    rm -f /tmp/.env.*
 
 # Set working directory
 WORKDIR /app

--- a/infra/bft/lib/container-bot-base.ts
+++ b/infra/bft/lib/container-bot-base.ts
@@ -814,11 +814,154 @@ OPTIONS:
     const inspectResult = await inspectCmd.output();
 
     if (!inspectResult.success) {
-      ui.error(
-        "❌ No container image found. Please build the container image first",
-      );
-      ui.output("💡 Run: bft codebot build");
-      throw new Error("Container image not found");
+      // No local image found, try pulling from ghcr.io
+      ui.output("📦 No local image found. Checking ghcr.io...");
+
+      try {
+        // Check if gh CLI is available
+        const ghCheckCmd = new Deno.Command("gh", {
+          args: ["--version"],
+          stdout: "null",
+          stderr: "null",
+        });
+        const ghCheckResult = await ghCheckCmd.output();
+
+        if (ghCheckResult.success) {
+          // Get current default registry
+          const defaultRegistryCmd = new Deno.Command("container", {
+            args: ["registry", "default", "inspect"],
+            stdout: "piped",
+            stderr: "null",
+          });
+          const defaultRegistryResult = await defaultRegistryCmd.output();
+          const currentRegistry = new TextDecoder().decode(
+            defaultRegistryResult.stdout,
+          ).trim();
+
+          // Set default registry to ghcr.io
+          ui.output("🔧 Setting default registry to ghcr.io...");
+          const setRegistryCmd = new Deno.Command("container", {
+            args: ["registry", "default", "set", "ghcr.io"],
+            stdout: "null",
+            stderr: "null",
+          });
+          await setRegistryCmd.output();
+
+          try {
+            // Login to ghcr.io using gh auth token
+            ui.output("🔐 Logging into ghcr.io...");
+            const ghUserCmd = new Deno.Command("gh", {
+              args: ["api", "user", "--jq", ".login"],
+              stdout: "piped",
+              stderr: "null",
+            });
+            const ghUserResult = await ghUserCmd.output();
+            const githubUser = new TextDecoder().decode(ghUserResult.stdout)
+              .trim();
+
+            const ghTokenCmd = new Deno.Command("gh", {
+              args: ["auth", "token"],
+              stdout: "piped",
+              stderr: "null",
+            });
+            const ghTokenResult = await ghTokenCmd.output();
+            const githubToken = new TextDecoder().decode(ghTokenResult.stdout)
+              .trim();
+
+            const loginCmd = new Deno.Command("container", {
+              args: [
+                "registry",
+                "login",
+                "--username",
+                githubUser,
+                "--password-stdin",
+                "ghcr.io",
+              ],
+              stdin: "piped",
+              stdout: "null",
+              stderr: "piped",
+            });
+            const loginProcess = loginCmd.spawn();
+            const writer = loginProcess.stdin.getWriter();
+            await writer.write(new TextEncoder().encode(githubToken));
+            await writer.close();
+            const loginResult = await loginProcess.output();
+
+            if (loginResult.success) {
+              ui.output("✅ Logged into ghcr.io");
+
+              // Try to pull the image
+              ui.output("🚢 Pulling codebot image from ghcr.io...");
+              const pullCmd = new Deno.Command("container", {
+                args: ["pull", "ghcr.io/bolt-foundry/bfmono/codebot:latest"],
+                stdout: "inherit",
+                stderr: "inherit",
+              });
+              const pullResult = await pullCmd.output();
+
+              if (pullResult.success) {
+                // Tag the pulled image as 'codebot' for local use
+                ui.output("🏷️  Tagging image as 'codebot'...");
+                const tagCmd = new Deno.Command("container", {
+                  args: [
+                    "tag",
+                    "ghcr.io/bolt-foundry/bfmono/codebot:latest",
+                    "codebot",
+                  ],
+                  stdout: "null",
+                  stderr: "null",
+                });
+                await tagCmd.output();
+
+                ui.output("✅ Successfully pulled codebot image from ghcr.io");
+
+                // Re-run the inspect command to continue with normal flow
+                const reInspectCmd = new Deno.Command("container", {
+                  args: ["images", "inspect", "codebot"],
+                  stdout: "piped",
+                  stderr: "null",
+                });
+                const reInspectResult = await reInspectCmd.output();
+
+                if (reInspectResult.success) {
+                  // Continue with the normal flow
+                  inspectResult.success = true;
+                  inspectResult.stdout = reInspectResult.stdout;
+                }
+              } else {
+                const pullError = new TextDecoder().decode(pullResult.stderr);
+                ui.warn(`⚠️  Failed to pull from ghcr.io: ${pullError}`);
+              }
+            } else {
+              const loginError = new TextDecoder().decode(loginResult.stderr);
+              ui.warn(`⚠️  Failed to login to ghcr.io: ${loginError}`);
+            }
+          } finally {
+            // Restore original default registry if it was different
+            if (currentRegistry && currentRegistry !== "ghcr.io") {
+              const restoreRegistryCmd = new Deno.Command("container", {
+                args: ["registry", "default", "set", currentRegistry],
+                stdout: "null",
+                stderr: "null",
+              });
+              await restoreRegistryCmd.output();
+            }
+          }
+        } else {
+          ui.warn("⚠️  GitHub CLI not available, skipping ghcr.io check");
+        }
+      } catch (error) {
+        ui.warn(`⚠️  Error checking ghcr.io: ${error}`);
+      }
+
+      // Final check - if we still don't have an image, fail
+      if (!inspectResult.success) {
+        ui.error(
+          "❌ No container image found locally or on ghcr.io",
+        );
+        ui.output("💡 Run: bft codebot build");
+        throw new Error("Container image not found");
+      }
     }
 
     // Parse the JSON output to get the creation date


### PR DESCRIPTION

- Check ghcr.io when no local codebot image exists
- Use GitHub CLI for authentication
- Preserve existing default registry settings
- Fall back to local build if pull fails
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/31).
* #33
* #32
* __->__ #31
* #30
* #29
* #28