### PR TITLE
fix: Correct Dockerfile path in build-codebot-container workflow

### DIFF
--- a/.github/workflows/build-codebot-container.yml
+++ b/.github/workflows/build-codebot-container.yml
@@ -112,7 +112,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ../internalbf
-          file: ./internalbf/bfmono/infra/Dockerfile.infra
+          file: ../internalbf/bfmono/infra/Dockerfile.infra
           push: ${{ !inputs.build_only }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION

The file path needs to be relative to the working directory, not the
context. Since we're setting context to ../internalbf, the file path
should also use ../ prefix to find the correct location.
