### PR TITLE
feat: Auto-start HTTPS proxy and boltfoundry-com in Docker containers

### DIFF
--- a/.github/workflows/build-codebot-container.yml
+++ b/.github/workflows/build-codebot-container.yml
@@ -32,8 +32,8 @@ jobs:
     permissions:
       contents: read
       packages: write
-      pull-requests: read  # Add this for PR builds
-      # id-token: write # For FlakeHub OIDC - commented out to avoid FlakeHub login
+      pull-requests: read # Add this for PR builds
+    # id-token: write # For FlakeHub OIDC - commented out to avoid FlakeHub login
 
     steps:
       - name: Checkout repository
@@ -152,7 +152,7 @@ jobs:
           platforms: linux/arm64
           build-args: |
             BUILDKIT_PROGRESS=plain
-      
+
       - name: Debug push failure
         if: ${{ failure() && steps.build.outcome == 'failure' }}
         run: |

--- a/infra/Dockerfile.infra
+++ b/infra/Dockerfile.infra
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     net-tools \
     ripgrep \
     fd-find \
+    authbind \
     # Chrome dependencies (we'll install Chrome separately)
     fonts-liberation \
     libasound2 \
@@ -163,11 +164,15 @@ if [ $# -eq 0 ] || [ "$1" = "-l" ]; then\n\
     \n\
     # Start HTTPS proxy if certificate exists\n\
     if [ -f "/internalbf/bfmono/shared/certs/codebot-wildcard.pem" ] && [ -f "/internalbf/bfmono/infra/apps/codebot/https-proxy-server.ts" ]; then\n\
-        # Grant deno capability to bind to privileged ports\n\
-        sudo setcap cap_net_bind_service=+ep $(which deno)\n\
-        # Start HTTPS proxy in background\n\
-        cd /internalbf/bfmono && deno run --allow-net --allow-read --allow-write infra/apps/codebot/https-proxy-server.ts > /tmp/https-proxy.log 2>&1 &\n\
+        # Start HTTPS proxy in background using authbind\n\
+        cd /internalbf/bfmono && authbind --deep deno run --allow-net --allow-read --allow-write --allow-env infra/apps/codebot/https-proxy-server.ts > /tmp/https-proxy.log 2>&1 &\n\
         echo "HTTPS proxy started in background (PID: $!)"\n\
+    fi\n\
+    \n\
+    # Start boltfoundry-com development server\n\
+    if [ -f "/internalbf/bfmono/infra/bft/bft.ts" ]; then\n\
+        cd /internalbf/bfmono && bft dev boltfoundry-com > /tmp/boltfoundry-com.log 2>&1 &\n\
+        echo "boltfoundry-com development server started in background"\n\
     fi\n\
 fi\n\
 \n\
@@ -180,15 +185,16 @@ RUN echo "# Allow codebot to manage /etc/hosts" >> /etc/sudoers.d/codebot && \
     echo "codebot ALL=(ALL) NOPASSWD: /bin/cp * /etc/hosts" >> /etc/sudoers.d/codebot && \
     echo "codebot ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/hosts" >> /etc/sudoers.d/codebot && \
     echo "codebot ALL=(ALL) NOPASSWD: /usr/bin/tee -a /etc/hosts" >> /etc/sudoers.d/codebot && \
-    echo "# Allow codebot to set capabilities on any file" >> /etc/sudoers.d/codebot && \
-    echo "codebot ALL=(ALL) NOPASSWD: /usr/sbin/setcap *" >> /etc/sudoers.d/codebot && \
-    echo "# Allow codebot to run HTTPS proxy with Deno from any path" >> /etc/sudoers.d/codebot && \
-    echo "codebot ALL=(ALL) NOPASSWD: /nix/store/*/bin/deno run * /internalbf/bfmono/infra/apps/codebot/https-proxy-server.ts" >> /etc/sudoers.d/codebot && \
-    echo "codebot ALL=(ALL) NOPASSWD: /usr/bin/deno run * /internalbf/bfmono/infra/apps/codebot/https-proxy-server.ts" >> /etc/sudoers.d/codebot && \
     chmod 0440 /etc/sudoers.d/codebot
 
 # Create non-root user (Debian uses useradd)
 RUN useradd -m -s /bin/bash codebot
+
+# Configure authbind for privileged ports
+RUN touch /etc/authbind/byport/80 && \
+    touch /etc/authbind/byport/443 && \
+    chown codebot:codebot /etc/authbind/byport/80 /etc/authbind/byport/443 && \
+    chmod 755 /etc/authbind/byport/80 /etc/authbind/byport/443
 
 # Create temp directory for Chrome with proper permissions
 RUN mkdir -p /home/codebot/tmp && \


### PR DESCRIPTION

- Add boltfoundry-com to Docker entrypoint startup sequence
- Add --allow-env permission to HTTPS proxy command
- Both services start automatically when codebot containers launch
- Logs written to /tmp/https-proxy.log and /tmp/boltfoundry-com.log
