### PR TITLE
Fix environment variable export for JWT_SECRET and other secrets

### DIFF
--- a/infra/Dockerfile.infra
+++ b/infra/Dockerfile.infra
@@ -288,13 +288,15 @@ fi
 
 # Load environment files if they exist
 if [ -f "/internalbf/bfmono/.env.config" ]; then
+  set -a
   source /internalbf/bfmono/.env.config
-  echo "✅ Loaded .env.config"
+  set +a
 fi
 
 if [ -f "/internalbf/bfmono/.env.secrets" ]; then
+  set -a
   source /internalbf/bfmono/.env.secrets
-  echo "✅ Loaded .env.secrets"
+  set +a
 fi
 
 # Add Nix and BF_ROOT to PATH

--- a/infra/bft/tasks/dev.bft.ts
+++ b/infra/bft/tasks/dev.bft.ts
@@ -203,6 +203,7 @@ Examples:
     // Use shell to execute the nohup command
     const backgroundProcess = new Deno.Command("sh", {
       args: ["-c", backgroundCommand],
+      env: Deno.env.toObject(), // Pass all current env vars including those from .env.secrets
     });
 
     const result = backgroundProcess.outputSync();


### PR DESCRIPTION

- Update dev.bft.ts to pass Deno.env.toObject() when spawning background processes
- Fix Dockerfile.infra to use 'set -a' when sourcing .env files in .bash_profile
- Remove noisy 'Loaded .env' echo statements from bash profile
- Ensures JWT_SECRET and other env vars from .env.secrets are properly exported to child processes
- Fixes authentication errors in boltfoundry-com dev server
