### PR TITLE
Remove deprecated config key references from packages and infra

### DIFF
--- a/apps/bfDs/components/BfDsCopyButton.tsx
+++ b/apps/bfDs/components/BfDsCopyButton.tsx
@@ -5,7 +5,7 @@
  */
 import * as React from "react";
 import { BfDsButton, type BfDsButtonProps } from "./BfDsButton.tsx";
-import { useCopyToClipboard } from "@bfmono/apps/boltFoundry/hooks/useCopyToClipboard.ts";
+import { useCopyToClipboard } from "@bfmono/packages/react-hooks/mod.ts";
 
 const { useState } = React;
 

--- a/apps/boltfoundry-com/components/RouterLink.tsx
+++ b/apps/boltfoundry-com/components/RouterLink.tsx
@@ -1,0 +1,21 @@
+import { useRouter } from "@bfmono/apps/boltfoundry-com/contexts/RouterContext.tsx";
+
+type LinkProps = {
+  to: string;
+  children?: React.ReactNode;
+} & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "href" | "onClick">;
+
+export function RouterLink({ to, children, ...props }: LinkProps) {
+  const { navigate } = useRouter();
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    navigate(to);
+  };
+
+  return (
+    <a href={to} onClick={handleClick} {...props}>
+      {children}
+    </a>
+  );
+}

--- a/infra/bff/friends/build.bff.ts
+++ b/infra/bff/friends/build.bff.ts
@@ -7,10 +7,9 @@ import {
 } from "@bfmono/packages/get-configuration-var/get-configuration-var.ts";
 import { getLogger } from "@bfmono/packages/logger/logger.ts";
 import { DeploymentEnvs } from "@bfmono/infra/constants/deploymentEnvs.ts";
-import {
-  PRIVATE_CONFIG_KEYS,
-  PUBLIC_CONFIG_KEYS,
-} from "@bfmono/apps/boltFoundry/__generated__/configKeys.ts";
+// Config keys import removed - deprecated functionality
+const PRIVATE_CONFIG_KEYS: Array<string> = [];
+const PUBLIC_CONFIG_KEYS: Array<string> = [];
 
 const logger = getLogger(import.meta);
 

--- a/infra/bff/friends/secrets.bff.ts
+++ b/infra/bff/friends/secrets.bff.ts
@@ -7,10 +7,9 @@ import {
   getSecret,
   warmSecrets,
 } from "@bolt-foundry/get-configuration-var";
-import {
-  PRIVATE_CONFIG_KEYS,
-  PUBLIC_CONFIG_KEYS,
-} from "@bfmono/apps/boltFoundry/__generated__/configKeys.ts";
+// Config keys import removed - deprecated functionality
+const PRIVATE_CONFIG_KEYS: Array<string> = [];
+const PUBLIC_CONFIG_KEYS: Array<string> = [];
 import { dirname } from "@std/path";
 import { exists } from "@std/fs";
 

--- a/packages/get-configuration-var/get-configuration-var.ts
+++ b/packages/get-configuration-var/get-configuration-var.ts
@@ -14,10 +14,7 @@
  * -----------------------------------------------------------------------------
  */
 
-import {
-  PRIVATE_CONFIG_KEYS,
-  PUBLIC_CONFIG_KEYS,
-} from "@bfmono/apps/boltFoundry/__generated__/configKeys.ts";
+// Config keys import removed - deprecated functionality
 
 /* ─── environment helpers ─────────────────────────────────────────────────── */
 const isDeno = typeof Deno !== "undefined" && !!Deno?.version?.deno;
@@ -90,4 +87,5 @@ export function writeEnv(): void {
 export const writeEnvFile = writeEnv;
 
 /* ─── exported for injection script ──────────────────────────────────────────── */
-export const KNOWN_KEYS = [...PUBLIC_CONFIG_KEYS, ...PRIVATE_CONFIG_KEYS];
+// KNOWN_KEYS removed - config key generation is deprecated
+export const KNOWN_KEYS: Array<string> = [];


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/82).
* #88
* #87
* #86
* #85
* #84
* #83
* __->__ #82
* #81
* #80