### PR TITLE
Fix SSH authentication in deployment workflow with verbose debugging

### DIFF
--- a/.github/workflows/deploy-boltfoundry-com.yml
+++ b/.github/workflows/deploy-boltfoundry-com.yml
@@ -70,10 +70,19 @@ jobs:
           # This ensures the SSH key persists for subsequent steps
           source .env.secrets
 
+          # Start SSH agent and add the key
+          eval "$(ssh-agent -s)"
+
           # Setup SSH directory and key
           mkdir -p ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
+
+          # Add the key to the SSH agent
+          ssh-add ~/.ssh/id_rsa
+
+          # Export SSH_AUTH_SOCK for subsequent steps
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
 
           # Note: ssh-keyscan will be done after we have the server IP
         env:
@@ -172,8 +181,33 @@ jobs:
           echo "GITHUB_TOKEN=${KAMAL_REGISTRY_PASSWORD}" > .kamal/secrets
           chmod 600 .kamal/secrets
 
+          # Set up SSH for this step since GitHub Actions doesn't persist SSH agent between steps
+          # We need to ensure the SSH key is available for Kamal
+          if [ -f ~/.ssh/id_rsa ]; then
+            echo "SSH key already exists at ~/.ssh/id_rsa"
+            echo "Key fingerprint: $(ssh-keygen -lf ~/.ssh/id_rsa)"
+          else
+            echo "Setting up SSH key for Kamal deployment"
+            source .env.secrets
+            mkdir -p ~/.ssh
+            echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+            chmod 600 ~/.ssh/id_rsa
+            echo "Created SSH key with fingerprint: $(ssh-keygen -lf ~/.ssh/id_rsa)"
+          fi
+
+          # Test SSH connection directly
+          echo "Testing SSH connection to ${{ steps.terraform_output.outputs.server_ip }}..."
+          ssh -o BatchMode=yes -o ConnectTimeout=5 root@${{ steps.terraform_output.outputs.server_ip }} "echo 'SSH connection successful'" || echo "Direct SSH test failed"
+
+          # Ensure StrictHostKeyChecking is disabled for the deployment
+          echo "Host ${{ steps.terraform_output.outputs.server_ip }}" >> ~/.ssh/config
+          echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+          echo "  UserKnownHostsFile /dev/null" >> ~/.ssh/config
+          chmod 600 ~/.ssh/config
+
           # Deploy with Kamal 2.x (will use .env for secret environment variables)
-          kamal deploy
+          # Use verbose mode to debug SSH issues
+          kamal deploy --verbose
         env:
           KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}


### PR DESCRIPTION

Add SSH agent setup and ensure SSH key is available in the Deploy with Kamal step.
Since GitHub Actions doesn't persist SSH agent between steps, we need to ensure
the SSH key is properly set up in the deployment step itself.

Added:
- Verbose mode for Kamal to debug SSH issues
- SSH key fingerprint logging
- Direct SSH connection test before Kamal deployment
- Disabled StrictHostKeyChecking for the deployment server
