### PR TITLE
Debug SSH key format issue

### DIFF
--- a/.github/workflows/deploy-boltfoundry-com.yml
+++ b/.github/workflows/deploy-boltfoundry-com.yml
@@ -75,11 +75,34 @@ jobs:
 
           # Setup SSH directory and key
           mkdir -p ~/.ssh
+          
+          # Debug: Check if SSH_PRIVATE_KEY starts with the right header
+          if echo "$SSH_PRIVATE_KEY" | head -1 | grep -q "BEGIN"; then
+            echo "SSH key appears to have correct header"
+          else
+            echo "WARNING: SSH key may be malformed"
+            echo "First line of key: $(echo "$SSH_PRIVATE_KEY" | head -1)"
+          fi
+          
+          # Write the key to file
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
+          
+          # Try to validate the key format
+          echo "Validating SSH key format..."
+          ssh-keygen -y -f ~/.ssh/id_rsa > /dev/null 2>&1 && echo "Key format is valid" || echo "Key format is INVALID"
 
-          # Add the key to the SSH agent
-          ssh-add ~/.ssh/id_rsa
+          # Verify the key is valid before proceeding
+          if ! ssh-keygen -y -f ~/.ssh/id_rsa > /dev/null 2>&1; then
+            echo "ERROR: SSH key format is invalid"
+            echo "Key content first 50 chars: $(head -c 50 ~/.ssh/id_rsa)"
+            echo "Key content last 50 chars: $(tail -c 50 ~/.ssh/id_rsa)"
+            # Don't exit yet - let's try to continue without SSH agent
+            echo "Will attempt to continue without SSH agent"
+          else
+            # Add the key to the SSH agent only if it's valid
+            ssh-add ~/.ssh/id_rsa || echo "Failed to add key to SSH agent, continuing anyway"
+          fi
 
           # Export SSH_AUTH_SOCK for subsequent steps
           echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV


### PR DESCRIPTION
The deployment is failing with 'error in libcrypto' when loading the SSH key.
This indicates the SSH_PRIVATE_KEY from 1Password may be in the wrong format.

Added diagnostics to:
- Check if the key has the correct header
- Validate the key format with ssh-keygen  
- Show partial key content if validation fails
- Continue deployment attempt even if SSH agent fails

This will help us understand if the SSH key in 1Password needs to be reformatted.