### PR TITLE
Convert Nav component to hybrid Isograph/hook approach

### DIFF
--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -111,6 +111,7 @@ type CurrentViewerLoggedIn implements CurrentViewer {
   id: ID
   orgBfOid: String
   organization: BfOrganization
+  person: BfPerson
   personBfGid: String
 }
 

--- a/apps/bfDb/graphql/graphqlContext.ts
+++ b/apps/bfDb/graphql/graphqlContext.ts
@@ -73,6 +73,7 @@ export async function createContext(
     request,
     responseHeaders,
   );
+
   logger.debug("Current viewer created");
 
   const ctx: BfGraphqlContext = {

--- a/apps/boltfoundry-com/__generated__/__isograph/CurrentViewer/LoginPage/param_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/CurrentViewer/LoginPage/param_type.ts
@@ -2,6 +2,24 @@
 export type CurrentViewer__LoginPage__param = {
   readonly data: {
     readonly __typename: string,
+    readonly id: (string | null),
+    readonly personBfGid: (string | null),
+    readonly orgBfOid: (string | null),
+    /**
+A client pointer for the CurrentViewerLoggedIn type.
+    */
+    readonly asCurrentViewerLoggedIn: ({
+      readonly organization: ({
+        readonly id: string,
+        readonly name: (string | null),
+        readonly domain: (string | null),
+      } | null),
+      readonly person: ({
+        readonly id: string,
+        readonly name: (string | null),
+        readonly email: (string | null),
+      } | null),
+    } | null),
   },
   readonly parameters: Record<PropertyKey, never>,
 };

--- a/apps/boltfoundry-com/__generated__/__isograph/CurrentViewer/LoginPage/resolver_reader.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/CurrentViewer/LoginPage/resolver_reader.ts
@@ -1,6 +1,7 @@
 import type {ComponentReaderArtifact, ExtractSecondParam, ReaderAst } from '@isograph/react';
 import { CurrentViewer__LoginPage__param } from './param_type.ts';
 import { LoginPage as resolver } from '../../../../components/LoginPage.tsx';
+import CurrentViewerLoggedIn__asCurrentViewerLoggedIn__resolver_reader from '../../CurrentViewerLoggedIn/asCurrentViewerLoggedIn/resolver_reader.ts';
 
 const readerAst: ReaderAst<CurrentViewer__LoginPage__param> = [
   {
@@ -9,6 +10,99 @@ const readerAst: ReaderAst<CurrentViewer__LoginPage__param> = [
     alias: null,
     arguments: null,
     isUpdatable: false,
+  },
+  {
+    kind: "Scalar",
+    fieldName: "id",
+    alias: null,
+    arguments: null,
+    isUpdatable: false,
+  },
+  {
+    kind: "Scalar",
+    fieldName: "personBfGid",
+    alias: null,
+    arguments: null,
+    isUpdatable: false,
+  },
+  {
+    kind: "Scalar",
+    fieldName: "orgBfOid",
+    alias: null,
+    arguments: null,
+    isUpdatable: false,
+  },
+  {
+    kind: "Linked",
+    fieldName: "asCurrentViewerLoggedIn",
+    alias: null,
+    arguments: null,
+    condition: CurrentViewerLoggedIn__asCurrentViewerLoggedIn__resolver_reader,
+    isUpdatable: false,
+    selections: [
+      {
+        kind: "Linked",
+        fieldName: "organization",
+        alias: null,
+        arguments: null,
+        condition: null,
+        isUpdatable: false,
+        selections: [
+          {
+            kind: "Scalar",
+            fieldName: "id",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+          {
+            kind: "Scalar",
+            fieldName: "name",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+          {
+            kind: "Scalar",
+            fieldName: "domain",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+        ],
+      },
+      {
+        kind: "Linked",
+        fieldName: "person",
+        alias: null,
+        arguments: null,
+        condition: null,
+        isUpdatable: false,
+        selections: [
+          {
+            kind: "Scalar",
+            fieldName: "id",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+          {
+            kind: "Scalar",
+            fieldName: "name",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+          {
+            kind: "Scalar",
+            fieldName: "email",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+        ],
+      },
+    ],
   },
 ];
 

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointEval/normalization_ast.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointEval/normalization_ast.ts
@@ -25,6 +25,11 @@ const normalizationAst: NormalizationAst = {
         },
         {
           kind: "Scalar",
+          fieldName: "__typename",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
           fieldName: "orgBfOid",
           arguments: null,
         },
@@ -110,6 +115,29 @@ const normalizationAst: NormalizationAst = {
                 {
                   kind: "Scalar",
                   fieldName: "domain",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "person",
+              arguments: null,
+              concreteType: "BfPerson",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "email",
                   arguments: null,
                 },
                 {

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointEval/param_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointEval/param_type.ts
@@ -3,6 +3,27 @@ import { type Query__Eval__output_type } from '../../Query/Eval/output_type.ts';
 export type Query__EntrypointEval__param = {
   readonly data: {
     readonly Eval: Query__Eval__output_type,
+    readonly currentViewer: ({
+      readonly __typename: string,
+      readonly id: (string | null),
+      readonly personBfGid: (string | null),
+      readonly orgBfOid: (string | null),
+      /**
+A client pointer for the CurrentViewerLoggedIn type.
+      */
+      readonly asCurrentViewerLoggedIn: ({
+        readonly organization: ({
+          readonly id: string,
+          readonly name: (string | null),
+          readonly domain: (string | null),
+        } | null),
+        readonly person: ({
+          readonly id: string,
+          readonly name: (string | null),
+          readonly email: (string | null),
+        } | null),
+      } | null),
+    } | null),
   },
   readonly parameters: Record<PropertyKey, never>,
 };

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointEval/query_text.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointEval/query_text.ts
@@ -3,6 +3,7 @@ export default 'query EntrypointEval  {\
   currentViewer {\
     __typename,\
     id,\
+    __typename,\
     orgBfOid,\
     personBfGid,\
     ... on CurrentViewerLoggedIn {\
@@ -21,6 +22,11 @@ export default 'query EntrypointEval  {\
           },\
         },\
         domain,\
+        name,\
+      },\
+      person {\
+        id,\
+        email,\
         name,\
       },\
     },\

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointEval/resolver_reader.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointEval/resolver_reader.ts
@@ -2,6 +2,7 @@ import type { EagerReaderArtifact, ReaderAst } from '@isograph/react';
 import { Query__EntrypointEval__param } from './param_type.ts';
 import { Query__EntrypointEval__output_type } from './output_type.ts';
 import { EntrypointEval as resolver } from '../../../../entrypoints/EntrypointEval.ts';
+import CurrentViewerLoggedIn__asCurrentViewerLoggedIn__resolver_reader from '../../CurrentViewerLoggedIn/asCurrentViewerLoggedIn/resolver_reader.ts';
 import Query__Eval__resolver_reader from '../../Query/Eval/resolver_reader.ts';
 
 const readerAst: ReaderAst<Query__EntrypointEval__param> = [
@@ -11,6 +12,116 @@ const readerAst: ReaderAst<Query__EntrypointEval__param> = [
     arguments: null,
     readerArtifact: Query__Eval__resolver_reader,
     usedRefetchQueries: [],
+  },
+  {
+    kind: "Linked",
+    fieldName: "currentViewer",
+    alias: null,
+    arguments: null,
+    condition: null,
+    isUpdatable: false,
+    selections: [
+      {
+        kind: "Scalar",
+        fieldName: "__typename",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "id",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "personBfGid",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "orgBfOid",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Linked",
+        fieldName: "asCurrentViewerLoggedIn",
+        alias: null,
+        arguments: null,
+        condition: CurrentViewerLoggedIn__asCurrentViewerLoggedIn__resolver_reader,
+        isUpdatable: false,
+        selections: [
+          {
+            kind: "Linked",
+            fieldName: "organization",
+            alias: null,
+            arguments: null,
+            condition: null,
+            isUpdatable: false,
+            selections: [
+              {
+                kind: "Scalar",
+                fieldName: "id",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "name",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "domain",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+            ],
+          },
+          {
+            kind: "Linked",
+            fieldName: "person",
+            alias: null,
+            arguments: null,
+            condition: null,
+            isUpdatable: false,
+            selections: [
+              {
+                kind: "Scalar",
+                fieldName: "id",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "name",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "email",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
 ];
 

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
@@ -14,6 +14,101 @@ const normalizationAst: NormalizationAst = {
     },
     {
       kind: "Linked",
+      fieldName: "currentViewer",
+      arguments: null,
+      concreteType: null,
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "__typename",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "__typename",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "orgBfOid",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "personBfGid",
+          arguments: null,
+        },
+        {
+          kind: "InlineFragment",
+          type: "CurrentViewerLoggedIn",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "organization",
+              arguments: null,
+              concreteType: "BfOrganization",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "domain",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "person",
+              arguments: null,
+              concreteType: "BfPerson",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "email",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      kind: "Linked",
       fieldName: "githubRepoStats",
       arguments: null,
       concreteType: "GithubRepoStats",

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/query_text.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/query_text.ts
@@ -1,6 +1,27 @@
 export default 'query EntrypointHome  {\
   id,\
   __typename,\
+  currentViewer {\
+    __typename,\
+    id,\
+    __typename,\
+    orgBfOid,\
+    personBfGid,\
+    ... on CurrentViewerLoggedIn {\
+      id,\
+      __typename,\
+      organization {\
+        id,\
+        domain,\
+        name,\
+      },\
+      person {\
+        id,\
+        email,\
+        name,\
+      },\
+    },\
+  },\
   githubRepoStats {\
     id,\
     stars,\

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointLogin/normalization_ast.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointLogin/normalization_ast.ts
@@ -28,6 +28,78 @@ const normalizationAst: NormalizationAst = {
           fieldName: "__typename",
           arguments: null,
         },
+        {
+          kind: "Scalar",
+          fieldName: "orgBfOid",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "personBfGid",
+          arguments: null,
+        },
+        {
+          kind: "InlineFragment",
+          type: "CurrentViewerLoggedIn",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "organization",
+              arguments: null,
+              concreteType: "BfOrganization",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "domain",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "person",
+              arguments: null,
+              concreteType: "BfPerson",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "email",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
       ],
     },
   ],

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointLogin/param_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointLogin/param_type.ts
@@ -3,7 +3,26 @@ import { type CurrentViewer__LoginPage__output_type } from '../../CurrentViewer/
 export type Query__EntrypointLogin__param = {
   readonly data: {
     readonly currentViewer: ({
+      readonly __typename: string,
+      readonly id: (string | null),
+      readonly personBfGid: (string | null),
+      readonly orgBfOid: (string | null),
       readonly LoginPage: CurrentViewer__LoginPage__output_type,
+      /**
+A client pointer for the CurrentViewerLoggedIn type.
+      */
+      readonly asCurrentViewerLoggedIn: ({
+        readonly organization: ({
+          readonly id: string,
+          readonly name: (string | null),
+          readonly domain: (string | null),
+        } | null),
+        readonly person: ({
+          readonly id: string,
+          readonly name: (string | null),
+          readonly email: (string | null),
+        } | null),
+      } | null),
     } | null),
   },
   readonly parameters: Record<PropertyKey, never>,

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointLogin/query_text.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointLogin/query_text.ts
@@ -4,5 +4,21 @@ export default 'query EntrypointLogin  {\
     __typename,\
     id,\
     __typename,\
+    orgBfOid,\
+    personBfGid,\
+    ... on CurrentViewerLoggedIn {\
+      id,\
+      __typename,\
+      organization {\
+        id,\
+        domain,\
+        name,\
+      },\
+      person {\
+        id,\
+        email,\
+        name,\
+      },\
+    },\
   },\
 }';

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointLogin/resolver_reader.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointLogin/resolver_reader.ts
@@ -3,6 +3,7 @@ import { Query__EntrypointLogin__param } from './param_type.ts';
 import { Query__EntrypointLogin__output_type } from './output_type.ts';
 import { EntrypointLogin as resolver } from '../../../../entrypoints/EntrypointLogin.ts';
 import CurrentViewer__LoginPage__resolver_reader from '../../CurrentViewer/LoginPage/resolver_reader.ts';
+import CurrentViewerLoggedIn__asCurrentViewerLoggedIn__resolver_reader from '../../CurrentViewerLoggedIn/asCurrentViewerLoggedIn/resolver_reader.ts';
 
 const readerAst: ReaderAst<Query__EntrypointLogin__param> = [
   {
@@ -14,11 +15,111 @@ const readerAst: ReaderAst<Query__EntrypointLogin__param> = [
     isUpdatable: false,
     selections: [
       {
+        kind: "Scalar",
+        fieldName: "__typename",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "id",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "personBfGid",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "orgBfOid",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
         kind: "Resolver",
         alias: "LoginPage",
         arguments: null,
         readerArtifact: CurrentViewer__LoginPage__resolver_reader,
         usedRefetchQueries: [],
+      },
+      {
+        kind: "Linked",
+        fieldName: "asCurrentViewerLoggedIn",
+        alias: null,
+        arguments: null,
+        condition: CurrentViewerLoggedIn__asCurrentViewerLoggedIn__resolver_reader,
+        isUpdatable: false,
+        selections: [
+          {
+            kind: "Linked",
+            fieldName: "organization",
+            alias: null,
+            arguments: null,
+            condition: null,
+            isUpdatable: false,
+            selections: [
+              {
+                kind: "Scalar",
+                fieldName: "id",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "name",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "domain",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+            ],
+          },
+          {
+            kind: "Linked",
+            fieldName: "person",
+            alias: null,
+            arguments: null,
+            condition: null,
+            isUpdatable: false,
+            selections: [
+              {
+                kind: "Scalar",
+                fieldName: "id",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "name",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "email",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+            ],
+          },
+        ],
       },
     ],
   },

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointRlhf/normalization_ast.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointRlhf/normalization_ast.ts
@@ -28,6 +28,78 @@ const normalizationAst: NormalizationAst = {
           fieldName: "__typename",
           arguments: null,
         },
+        {
+          kind: "Scalar",
+          fieldName: "orgBfOid",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "personBfGid",
+          arguments: null,
+        },
+        {
+          kind: "InlineFragment",
+          type: "CurrentViewerLoggedIn",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "organization",
+              arguments: null,
+              concreteType: "BfOrganization",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "domain",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "person",
+              arguments: null,
+              concreteType: "BfPerson",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "email",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
       ],
     },
   ],

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointRlhf/query_text.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointRlhf/query_text.ts
@@ -4,5 +4,21 @@ export default 'query EntrypointRlhf  {\
     __typename,\
     id,\
     __typename,\
+    orgBfOid,\
+    personBfGid,\
+    ... on CurrentViewerLoggedIn {\
+      id,\
+      __typename,\
+      organization {\
+        id,\
+        domain,\
+        name,\
+      },\
+      person {\
+        id,\
+        email,\
+        name,\
+      },\
+    },\
   },\
 }';

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/Eval/param_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/Eval/param_type.ts
@@ -9,6 +9,11 @@ export type Query__Eval__param = {
 A client pointer for the CurrentViewerLoggedIn type.
       */
       readonly asCurrentViewerLoggedIn: ({
+        readonly person: ({
+          readonly id: string,
+          readonly name: (string | null),
+          readonly email: (string | null),
+        } | null),
         readonly organization: ({
           readonly id: string,
           readonly name: (string | null),

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/Eval/resolver_reader.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/Eval/resolver_reader.ts
@@ -43,6 +43,37 @@ const readerAst: ReaderAst<Query__Eval__param> = [
         selections: [
           {
             kind: "Linked",
+            fieldName: "person",
+            alias: null,
+            arguments: null,
+            condition: null,
+            isUpdatable: false,
+            selections: [
+              {
+                kind: "Scalar",
+                fieldName: "id",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "name",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "email",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+            ],
+          },
+          {
+            kind: "Linked",
             fieldName: "organization",
             alias: null,
             arguments: null,

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/Home/param_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/Home/param_type.ts
@@ -5,6 +5,27 @@ export type Query__Home__param = {
     readonly githubRepoStats: ({
       readonly stars: number,
     } | null),
+    readonly currentViewer: ({
+      readonly __typename: string,
+      readonly id: (string | null),
+      readonly personBfGid: (string | null),
+      readonly orgBfOid: (string | null),
+      /**
+A client pointer for the CurrentViewerLoggedIn type.
+      */
+      readonly asCurrentViewerLoggedIn: ({
+        readonly organization: ({
+          readonly id: string,
+          readonly name: (string | null),
+          readonly domain: (string | null),
+        } | null),
+        readonly person: ({
+          readonly id: string,
+          readonly name: (string | null),
+          readonly email: (string | null),
+        } | null),
+      } | null),
+    } | null),
   },
   readonly parameters: Record<PropertyKey, never>,
 };

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/Home/resolver_reader.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/Home/resolver_reader.ts
@@ -1,6 +1,7 @@
 import type {ComponentReaderArtifact, ExtractSecondParam, ReaderAst } from '@isograph/react';
 import { Query__Home__param } from './param_type.ts';
 import { Home as resolver } from '../../../../components/Home.tsx';
+import CurrentViewerLoggedIn__asCurrentViewerLoggedIn__resolver_reader from '../../CurrentViewerLoggedIn/asCurrentViewerLoggedIn/resolver_reader.ts';
 
 const readerAst: ReaderAst<Query__Home__param> = [
   {
@@ -24,6 +25,116 @@ const readerAst: ReaderAst<Query__Home__param> = [
         alias: null,
         arguments: null,
         isUpdatable: false,
+      },
+    ],
+  },
+  {
+    kind: "Linked",
+    fieldName: "currentViewer",
+    alias: null,
+    arguments: null,
+    condition: null,
+    isUpdatable: false,
+    selections: [
+      {
+        kind: "Scalar",
+        fieldName: "__typename",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "id",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "personBfGid",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "orgBfOid",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Linked",
+        fieldName: "asCurrentViewerLoggedIn",
+        alias: null,
+        arguments: null,
+        condition: CurrentViewerLoggedIn__asCurrentViewerLoggedIn__resolver_reader,
+        isUpdatable: false,
+        selections: [
+          {
+            kind: "Linked",
+            fieldName: "organization",
+            alias: null,
+            arguments: null,
+            condition: null,
+            isUpdatable: false,
+            selections: [
+              {
+                kind: "Scalar",
+                fieldName: "id",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "name",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "domain",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+            ],
+          },
+          {
+            kind: "Linked",
+            fieldName: "person",
+            alias: null,
+            arguments: null,
+            condition: null,
+            isUpdatable: false,
+            selections: [
+              {
+                kind: "Scalar",
+                fieldName: "id",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "name",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+              {
+                kind: "Scalar",
+                fieldName: "email",
+                alias: null,
+                arguments: null,
+                isUpdatable: false,
+              },
+            ],
+          },
+        ],
       },
     ],
   },

--- a/apps/boltfoundry-com/components/Eval.tsx
+++ b/apps/boltfoundry-com/components/Eval.tsx
@@ -29,6 +29,11 @@ export const Eval = iso(`
       personBfGid
       orgBfOid
       asCurrentViewerLoggedIn {
+        person {
+          id
+          name
+          email
+        }
         organization {
           id
           name

--- a/apps/boltfoundry-com/components/Evals/Layout/Header.tsx
+++ b/apps/boltfoundry-com/components/Evals/Layout/Header.tsx
@@ -2,13 +2,15 @@ import { Nav } from "@bfmono/apps/boltfoundry-com/components/Nav.tsx";
 import { useEvalContext } from "@bfmono/apps/boltfoundry-com/contexts/EvalContext.tsx";
 
 export function Header() {
-  const { setLeftSidebarOpen, leftSidebarOpen } = useEvalContext();
+  const { setLeftSidebarOpen, leftSidebarOpen, currentViewer } =
+    useEvalContext();
 
   return (
     <Nav
       page="eval"
       onSidebarToggle={() => setLeftSidebarOpen(!leftSidebarOpen)}
       sidebarOpen={leftSidebarOpen}
+      currentViewer={currentViewer}
     />
   );
 }

--- a/apps/boltfoundry-com/components/Home.tsx
+++ b/apps/boltfoundry-com/components/Home.tsx
@@ -10,6 +10,24 @@ export const Home = iso(`
     githubRepoStats {
       stars
     }
+    currentViewer {
+      __typename
+      id
+      personBfGid
+      orgBfOid
+      asCurrentViewerLoggedIn {
+        organization {
+          id
+          name
+          domain
+        }
+        person {
+          id
+          name
+          email
+        }
+      }
+    }
   }
 `)(function Home({ data }) {
   const heroRef = useRef<HTMLDivElement>(null);
@@ -30,7 +48,7 @@ export const Home = iso(`
   return (
     <div className="landing-page">
       {/* Navigation Header */}
-      <Nav page="home" />
+      <Nav currentViewer={data.currentViewer} page="home" />
 
       {/* Hero Section */}
       <main className="hero-section flexColumn" ref={heroRef}>

--- a/apps/boltfoundry-com/components/LoginPage.tsx
+++ b/apps/boltfoundry-com/components/LoginPage.tsx
@@ -5,12 +5,27 @@ import { Nav } from "./Nav.tsx";
 export const LoginPage = iso(`
   field CurrentViewer.LoginPage @component {
     __typename
+    id
+    personBfGid
+    orgBfOid
+    asCurrentViewerLoggedIn {
+      organization {
+        id
+        name
+        domain
+      }
+      person {
+        id
+        name
+        email
+      }
+    }
   }
 `)(function LoginPageComponent({ data }) {
   if (data.__typename === "CurrentViewerLoggedIn") {
     return (
       <div className="landing-page with-header">
-        <Nav page="login" />
+        <Nav page="login" currentViewer={data} />
         <div className="landing-content">
           <h1>Already Signed In</h1>
           <p>Welcome back! You're already signed in.</p>
@@ -21,7 +36,7 @@ export const LoginPage = iso(`
 
   return (
     <div className="landing-page with-header">
-      <Nav page="login" />
+      <Nav page="login" currentViewer={data} />
       <div className="landing-content">
         <h1>Sign In to Bolt Foundry</h1>
         <p>Sign in with your Google Workspace account to continue</p>

--- a/apps/boltfoundry-com/entrypoints/EntrypointEval.ts
+++ b/apps/boltfoundry-com/entrypoints/EntrypointEval.ts
@@ -6,10 +6,29 @@ const logger = getLogger(import.meta);
 export const EntrypointEval = iso(`
   field Query.EntrypointEval {
     Eval
+    currentViewer {
+      __typename
+      id
+      personBfGid
+      orgBfOid
+      asCurrentViewerLoggedIn {
+        organization {
+          id
+          name
+          domain
+        }
+        person {
+          id
+          name
+          email
+        }
+      }
+    }
   }
 `)(function EntrypointEval({ data }) {
   const Body = data.Eval;
   logger.debug("dataer", data);
   const title = "Eval - Bolt Foundry";
+
   return { Body, title };
 });

--- a/apps/boltfoundry-com/entrypoints/EntrypointHome.ts
+++ b/apps/boltfoundry-com/entrypoints/EntrypointHome.ts
@@ -11,5 +11,6 @@ export const EntrypointHome = iso(`
   const Body = data.Home;
   logger.debug("dataer", data);
   const title = "Bolt Foundry: Unit Tests for LLMs.";
+
   return { Body, title };
 });

--- a/apps/boltfoundry-com/entrypoints/EntrypointLogin.ts
+++ b/apps/boltfoundry-com/entrypoints/EntrypointLogin.ts
@@ -3,11 +3,28 @@ import { iso } from "@iso-bfc";
 export const EntrypointLogin = iso(`
   field Query.EntrypointLogin {
     currentViewer {
+      __typename
+      id
+      personBfGid
+      orgBfOid
       LoginPage
+      asCurrentViewerLoggedIn {
+        organization {
+          id
+          name
+          domain
+        }
+        person {
+          id
+          name
+          email
+        }
+      }
     }
   }
 `)(function EntrypointLogin({ data }) {
   const Body = data.currentViewer?.LoginPage;
   const title = "Sign In - Bolt Foundry";
+
   return { Body, title };
 });

--- a/apps/boltfoundry-com/entrypoints/EntrypointRlhf.ts
+++ b/apps/boltfoundry-com/entrypoints/EntrypointRlhf.ts
@@ -17,5 +17,6 @@ export const EntrypointRlhf = iso(`
 
   const Body = data.currentViewer?.RlhfHome;
   const title = "RLHF - Bolt Foundry";
+
   return { Body, title };
 });

--- a/apps/boltfoundry-com/handlers/logout.ts
+++ b/apps/boltfoundry-com/handlers/logout.ts
@@ -1,4 +1,5 @@
 import { getLogger } from "@bolt-foundry/logger";
+import { clearAuthCookies } from "@bfmono/apps/bfDb/graphql/utils/graphqlContextUtils.ts";
 
 const logger = getLogger(import.meta);
 
@@ -7,19 +8,12 @@ export function handleLogoutRequest(
 ): Response {
   logger.info("Processing logout request");
 
-  // Clear authentication cookies by setting them with expired dates
+  // Clear authentication cookies using the utility function
   const headers = new Headers({
     "Location": "/",
-    // Clear bf_access cookie
-    "Set-Cookie":
-      "bf_access=; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
   });
 
-  // Add second Set-Cookie header for bf_refresh cookie
-  headers.append(
-    "Set-Cookie",
-    "bf_refresh=; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
-  );
+  clearAuthCookies(headers);
 
   logger.info("Logout successful, clearing cookies and redirecting to /");
 


### PR DESCRIPTION

Updated Nav component to work consistently across Isograph and non-Isograph pages.
  - Added hybrid data fetching with currentViewer prop fallback to useCurrentViewer hook
  - Fixed conditional logic to handle both Isograph and raw GraphQL data structures
  - Updated all entrypoints to fetch currentViewer data for Nav component
  - Nav now displays user names correctly on all pages (/ui, /eval, /home, etc.)

Fix logout

  🤖 Generated with [Claude Code](https://claude.ai/code)

  Co-Authored-By: Claude <noreply@anthropic.com>
