### PR TITLE
refactor: Remove environment-based deployments to eliminate PR spam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,11 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: ci
     permissions:
       contents: read
       id-token: write # OIDC for FlakeHub
     env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CI_OP_SERVICE_ACCOUNT_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -93,13 +92,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: ci
     needs: setup
     permissions:
       contents: read
       id-token: write
     env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CI_OP_SERVICE_ACCOUNT_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -134,13 +132,12 @@ jobs:
   format:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: ci
     needs: setup
     permissions:
       contents: read
       id-token: write
     env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CI_OP_SERVICE_ACCOUNT_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -175,13 +172,12 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: ci
     needs: setup
     permissions:
       contents: read
       id-token: write
     env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CI_OP_SERVICE_ACCOUNT_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -216,13 +212,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: ci
     needs: setup
     permissions:
       contents: read
       id-token: write
     env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CI_OP_SERVICE_ACCOUNT_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -257,13 +252,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: ci
     needs: setup
     permissions:
       contents: read
       id-token: write
     env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CI_OP_SERVICE_ACCOUNT_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -311,13 +305,12 @@ jobs:
   docker-build-validation:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: ci
     needs: [build]
     permissions:
       contents: read
       id-token: write
     env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CI_OP_SERVICE_ACCOUNT_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -438,13 +431,12 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: ci
     needs: [build]
     permissions:
       contents: read
       id-token: write
     env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CI_OP_SERVICE_ACCOUNT_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-boltfoundry-com.yml
+++ b/.github/workflows/deploy-boltfoundry-com.yml
@@ -16,7 +16,6 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: production
     permissions:
       contents: read
       packages: write
@@ -32,14 +31,14 @@ jobs:
           nix develop .#production --accept-flake-config --command bash -c "
             # Sync environment variables from vault accessible by service account
             # The OP_SERVICE_ACCOUNT_TOKEN determines which vault is used
-            if [ -n \"${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}\" ]; then
+            if [ -n \"${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}\" ]; then
               bft sitevar sync --force
             fi
             # Build the binary
             bft compile boltfoundry-com
           "
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Login to GitHub Container Registry
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -61,7 +60,7 @@ jobs:
         run: |
           # First sync secrets from 1Password to get SSH_PRIVATE_KEY
           nix develop .#production --accept-flake-config --command bash -euc "
-            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
+            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}'
             # Sync all secrets from 1Password
             # Note: We only sync secrets here for SSH setup
             # Full sync happens in the deployment step
@@ -103,7 +102,7 @@ jobs:
 
           # Note: ssh-keyscan will be done after we have the server IP
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -113,7 +112,7 @@ jobs:
         run: |
           # First sync secrets from 1Password
           nix develop .#production --accept-flake-config --command bash -euc "
-            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
+            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}'
 
             # Sync all secrets to .env.secrets
             bft sitevar sync --force
@@ -178,7 +177,7 @@ jobs:
         run: |
           # Sync production config and secrets from 1Password and generate Kamal config
           nix develop .#production --accept-flake-config --command bash -c "
-            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
+            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}'
 
             # Sync ALL variables (both config and secrets) from 1Password
             bft sitevar sync --force
@@ -255,7 +254,7 @@ jobs:
           kamal deploy --verbose
         env:
           KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}
           BOLTFOUNDRY_COM_SERVER_IP: ${{ steps.terraform_output.outputs.server_ip }}
         working-directory: ./
 

--- a/.github/workflows/deploy-promptgrade-ai.yml
+++ b/.github/workflows/deploy-promptgrade-ai.yml
@@ -16,7 +16,6 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: production
     permissions:
       contents: read
       packages: write
@@ -31,14 +30,14 @@ jobs:
           nix develop .#production --accept-flake-config --command bash -c "
             # Sync environment variables from vault accessible by service account
             # The OP_SERVICE_ACCOUNT_TOKEN determines which vault is used
-            if [ -n \"${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}\" ]; then
+            if [ -n \"${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}\" ]; then
               bft sitevar sync --force
             fi
             # Build the binary
             bft compile promptgrade-ai
           "
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Login to GitHub Container Registry
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -77,7 +76,7 @@ jobs:
         run: |
           # First sync secrets from 1Password
           nix develop .#production --accept-flake-config --command bash -euc "
-            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
+            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}'
 
             # Sync all secrets to .env.secrets
             bft sitevar sync --force
@@ -138,7 +137,7 @@ jobs:
         run: |
           # Sync production secrets from 1Password and generate Kamal config
           nix develop .#production --accept-flake-config --command bash -c "
-            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
+            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}'
 
             # Sync all secrets from 1Password
             bft sitevar sync --force --secret-only
@@ -159,7 +158,7 @@ jobs:
           kamal deploy
         env:
           KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}
         working-directory: ./
 
       - name: Validate deployment health

--- a/.github/workflows/notify-internalbf.yml
+++ b/.github/workflows/notify-internalbf.yml
@@ -16,9 +16,8 @@ jobs:
   notify-internalbf:
     name: Trigger internalbf submodule update
     runs-on: ubuntu-latest
-    environment: ci
     env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CI_OP_SERVICE_ACCOUNT_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION

- Replace environment-specific secrets with repository secrets
- Use CI_OP_SERVICE_ACCOUNT_TOKEN for CI workflows
- Use PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN for production deployments
- Keep infrastructure environment for Terraform workflows with approval protection
- Remove 'environment: ci' and 'environment: production' declarations

This change eliminates the deployment spam in PRs while maintaining proper
secret separation between CI and production through 1Password vaults.
