### PR TITLE
Add containerStartup command and update statusLine configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,5 +52,9 @@
       }
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "if pgrep -f \"bft dev boltfoundry-com\" > /dev/null 2>&1 || pgrep -f \"deno.*boltfoundry-com\" > /dev/null 2>&1 || (lsof -i :8000 > /dev/null 2>&1); then echo \"🟢 bft https://$(hostname).codebot.local\"; else echo \"⭕ bft https://$(hostname).codebot.local\"; fi"
+  },
   "$schema": "https://json.schemastore.org/claude-code-settings.json"
 }

--- a/infra/Dockerfile.infra
+++ b/infra/Dockerfile.infra
@@ -190,17 +190,10 @@ if [ $# -eq 0 ] || [ "$1" = "-l" ]; then\n\
         echo "Container bridge started in background (PID: $!)"\n\
     fi\n\
     \n\
-    # Start HTTPS proxy if certificate exists\n\
-    if [ -f "/internalbf/bfmono/shared/certs/codebot-wildcard.pem" ] && [ -f "/internalbf/bfmono/infra/bft/bft.ts" ]; then\n\
-        # Start HTTPS proxy in background using bft proxy command\n\
-        cd /internalbf/bfmono && bft proxy --start > /tmp/bft-proxy-start.log 2>&1 &\n\
-        echo "HTTPS proxy starting via bft proxy command"\n\
-    fi\n\
-    \n\
-    # Start boltfoundry-com development server\n\
+    # Start container services using unified startup command\n\
     if [ -f "/internalbf/bfmono/infra/bft/bft.ts" ]; then\n\
-        cd /internalbf/bfmono && bft dev boltfoundry-com > /tmp/boltfoundry-com.log 2>&1 &\n\
-        echo "boltfoundry-com development server started in background"\n\
+        cd /internalbf/bfmono && bft containerStartup > /tmp/container-startup.log 2>&1 &\n\
+        echo "Container services starting via bft containerStartup"\n\
     fi\n\
 fi\n\
 \n\

--- a/infra/bft/tasks/containerStartup.bft.ts
+++ b/infra/bft/tasks/containerStartup.bft.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env -S deno run -A
+
+import { getLogger } from "@bolt-foundry/logger";
+import type { TaskDefinition } from "../bft.ts";
+
+const logger = getLogger(import.meta);
+
+async function exec(
+  cmd: string,
+): Promise<{ stdout: string; stderr: string; success: boolean }> {
+  const command = new Deno.Command("sh", {
+    args: ["-c", cmd],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const output = await command.output();
+  const stdout = new TextDecoder().decode(output.stdout);
+  const stderr = new TextDecoder().decode(output.stderr);
+
+  return { stdout, stderr, success: output.success };
+}
+
+async function checkProcess(pattern: string): Promise<boolean> {
+  try {
+    const { stdout } = await exec(
+      `pgrep -f "${pattern}" > /dev/null 2>&1 && echo "running"`,
+    );
+    return stdout.trim() === "running";
+  } catch {
+    return false;
+  }
+}
+
+async function containerStartup(): Promise<number> {
+  logger.info("🚀 Starting container services...");
+
+  // Check and start HTTPS proxy
+  logger.info("Checking HTTPS proxy status...");
+  const proxyRunning = await checkProcess("https-proxy-server.ts");
+
+  if (!proxyRunning) {
+    logger.info("Starting HTTPS proxy...");
+    const { success, stderr } = await exec("bft proxy --start");
+
+    if (!success) {
+      logger.error("Failed to start HTTPS proxy:", stderr);
+      return 1;
+    }
+
+    // Wait for proxy to fully start
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    logger.info("✅ HTTPS proxy started");
+  } else {
+    logger.info("✅ HTTPS proxy already running");
+  }
+
+  // Check and start boltfoundry-com dev server
+  logger.info("Checking boltfoundry-com dev server status...");
+  const devServerRunning = await checkProcess("bft dev boltfoundry-com") ||
+    await checkProcess("deno.*boltfoundry-com") ||
+    await checkProcess("vite.*boltfoundry-com");
+
+  if (!devServerRunning) {
+    logger.info("Starting boltfoundry-com dev server...");
+
+    // Start dev server in background
+    const logFile = "/tmp/boltfoundry-com-dev.log";
+    const startCmd =
+      `cd /internalbf/bfmono && nohup bft dev boltfoundry-com > ${logFile} 2>&1 &`;
+
+    const { success, stderr } = await exec(startCmd);
+
+    if (!success && stderr) {
+      logger.error("Failed to start dev server:", stderr);
+      return 1;
+    }
+
+    // Wait for server to start
+    logger.info("Waiting for dev server to initialize...");
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    // Verify it started
+    const isRunning = await checkProcess("boltfoundry-com");
+    if (isRunning) {
+      logger.info("✅ boltfoundry-com dev server started");
+      logger.info(`   Logs: ${logFile}`);
+    } else {
+      logger.warn("⚠️  Dev server may not have started properly");
+      logger.info(`   Check logs: ${logFile}`);
+    }
+  } else {
+    logger.info("✅ boltfoundry-com dev server already running");
+  }
+
+  // Show final status
+  logger.info("\n📊 Container services status:");
+  logger.info("   HTTPS Proxy: https://*.codebot.local");
+  logger.info(
+    "   Dev Server: https://" + (await exec("hostname")).stdout.trim() +
+      ".codebot.local",
+  );
+
+  // Show how to check logs
+  logger.info("\n📝 To view logs:");
+  logger.info("   Proxy: bft proxy --logs");
+  logger.info("   Dev server: tail -f /tmp/boltfoundry-com-dev.log");
+
+  return 0;
+}
+
+export const bftDefinition = {
+  description:
+    "Start essential container services (HTTPS proxy and dev server)",
+  fn: containerStartup,
+} satisfies TaskDefinition;


### PR DESCRIPTION

- Created bft containerStartup command to initialize container services
  - Automatically starts HTTPS proxy server
  - Automatically starts boltfoundry-com dev server
  - Provides status feedback and log locations

- Updated statusLine in .claude/settings.json
  - Shows 'bft https://hostname.codebot.local' format
  - Green indicator (🟢) when services are running
  - Red hollow circle (⭕) when services are not running

- Modified Dockerfile.infra to use containerStartup
  - Replaced separate proxy and dev server startup with unified command
  - Services now start automatically when container launches
