### PR TITLE
fix: Replace curl with gh api in notify-internalbf workflow

### DIFF
--- a/.github/workflows/notify-internalbf.yml
+++ b/.github/workflows/notify-internalbf.yml
@@ -41,11 +41,10 @@ jobs:
             # Determine target branch
             TARGET_BRANCH=\"${{ github.event.inputs.target_branch || 'main' }}\"
 
-            # Trigger the internalbf workflow
-            curl -X POST \
-              -H \"Accept: application/vnd.github+json\" \
-              -H \"Authorization: Bearer \$CODEBOT_GITHUB_PAT\" \
-              -H \"X-GitHub-Api-Version: 2022-11-28\" \
-              https://api.github.com/repos/bolt-foundry/internalbf/dispatches \
-              -d \"{\\\"event_type\\\":\\\"update-bfmono-submodule\\\",\\\"client_payload\\\":{\\\"target_branch\\\":\\\"\$TARGET_BRANCH\\\"}}\"
+            # Trigger the internalbf workflow using gh CLI
+            GH_TOKEN=\$CODEBOT_GITHUB_PAT gh api \
+              repos/bolt-foundry/internalbf/dispatches \
+              --method POST \
+              --field event_type='update-bfmono-submodule' \
+              --field \"client_payload[target_branch]=\$TARGET_BRANCH\"
           "


### PR DESCRIPTION

The repository_dispatch event was not being triggered from bfmono to internalbf
due to malformed JSON in the curl command. The triple-escaped quotes resulted
in invalid JSON being sent to the GitHub API.

Replaced curl with gh api which:
- Properly handles JSON formatting automatically
- Uses --field parameters for clean value passing
- Eliminates complex escape sequences
- Should correctly trigger the update-bfmono-submodule workflow in internalbf
