### PR TITLE
Add containerStartup command and update statusLine configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,7 +54,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "if pgrep -f \"bft dev boltfoundry-com\" > /dev/null 2>&1 || pgrep -f \"deno.*boltfoundry-com\" > /dev/null 2>&1 || (lsof -i :8000 > /dev/null 2>&1); then echo \"🟢 bft https://$(hostname).codebot.local\"; else echo \"⭕ bft https://$(hostname).codebot.local\"; fi"
+    "command": "hostname=$(hostname); if curl -s --connect-timeout 1 http://localhost:8000 > /dev/null 2>&1 || nc -z localhost 8000 2>/dev/null; then echo \"🟢 bft https://${hostname}.codebot.local\"; else echo \"⭕ bft https://${hostname}.codebot.local\"; fi"
   },
   "$schema": "https://json.schemastore.org/claude-code-settings.json"
 }


### PR DESCRIPTION

- Created bft containerStartup command to initialize container services
  - Automatically starts HTTPS proxy server
  - Automatically starts boltfoundry-com dev server
  - Provides status feedback and log locations

- Updated statusLine in .claude/settings.json
  - Shows 'bft https://hostname.codebot.local' format
  - Green indicator (🟢) when services are running
  - Red hollow circle (⭕) when services are not running

- Modified Dockerfile.infra to use containerStartup
  - Replaced separate proxy and dev server startup with unified command
  - Services now start automatically when container launches
