### PR TITLE
fix: Remove working-directory default from Terraform workflow to fix bft command

### DIFF
--- a/.github/workflows/infrastructure-hetzner.yml
+++ b/.github/workflows/infrastructure-hetzner.yml
@@ -15,9 +15,6 @@ jobs:
   terraform:
     runs-on: ubuntu-latest
     environment: infrastructure
-    defaults:
-      run:
-        working-directory: infra/terraform/hetzner
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

The GitHub Actions workflow was failing with 'bft: command not found' because
the working-directory default was set to infra/terraform/hetzner, causing
$BF_ROOT to be set incorrectly when the Nix shell initialized.

By removing the working-directory default and running from the repository root,
the Nix shell properly sets up the PATH with $BF_ROOT/infra/bin, making the
bft command available for syncing sitevars from 1Password.
