### PR TITLE
fix: Remove working-directory from terraform-operations workflow

### DIFF
--- a/.github/workflows/terraform-operations.yml
+++ b/.github/workflows/terraform-operations.yml
@@ -31,9 +31,6 @@ jobs:
   terraform-operation:
     runs-on: ubuntu-latest
     environment: infrastructure
-    defaults:
-      run:
-        working-directory: infra/terraform/hetzner
 
     steps:
       - name: Validate destroy operation


### PR DESCRIPTION

The terraform-operations.yml workflow has the same issue as the
infrastructure-hetzner.yml workflow - the working-directory default
prevents bft from being found in the PATH.

Removing the working-directory default allows the Nix shell to properly
set up /internalbf/bfmono and make the bft command available.
