### PR TITLE
fix: include AWS S3 credentials in runtime secrets for asset uploads

### DIFF
--- a/.github/workflows/deploy-boltfoundry-com.yml
+++ b/.github/workflows/deploy-boltfoundry-com.yml
@@ -263,7 +263,7 @@ jobs:
             for var in $(grep "^[A-Z_]*=" .env.secrets | cut -d= -f1); do
               # Skip infrastructure and deployment secrets
               case "$var" in
-                SSH_PRIVATE_KEY|SSH_PUBLIC_KEY|HETZNER_API_TOKEN|CLOUDFLARE_*|TERRAFORM_*|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|GITHUB_PERSONAL_ACCESS_TOKEN|HETZNER_PROJECT_ID|S3_ENDPOINT|*_SERVER_IP)
+                SSH_PRIVATE_KEY|SSH_PUBLIC_KEY|HETZNER_API_TOKEN|CLOUDFLARE_*|TERRAFORM_*|GITHUB_PERSONAL_ACCESS_TOKEN|HETZNER_PROJECT_ID|S3_ENDPOINT|*_SERVER_IP)
                   # Skip these - not needed at runtime
                   ;;
                 *)

--- a/infra/bft/tasks/generate-kamal-config.bft.ts
+++ b/infra/bft/tasks/generate-kamal-config.bft.ts
@@ -88,8 +88,6 @@ async function generateKamalConfig(args: Array<string>): Promise<number> {
       "TERRAFORM_BACKEND_ACCESS_KEY_ID", // CI infrastructure
       "TERRAFORM_BACKEND_SECRET_ACCESS_KEY", // CI infrastructure
       "TERRAFORM_BACKEND_ENDPOINT", // CI infrastructure
-      "AWS_ACCESS_KEY_ID", // Handled separately
-      "AWS_SECRET_ACCESS_KEY", // Handled separately
       "GITHUB_PERSONAL_ACCESS_TOKEN", // Not needed at runtime
       "SSH_PUBLIC_KEY", // Not needed at runtime
       "SSH_PRIVATE_KEY", // Not needed at runtime

--- a/infra/bft/tasks/generate-kamal-config.bft.ts
+++ b/infra/bft/tasks/generate-kamal-config.bft.ts
@@ -99,6 +99,8 @@ async function generateKamalConfig(args: Array<string>): Promise<number> {
       "CLOUDFLARE_API_TOKEN", // Infrastructure management only
       "CLOUDFLARE_ZONE_ID", // Infrastructure management only
       "CLOUDFLARE_ZONE_ID_PROMPTGRADE", // Infrastructure management only
+      "CLOUDFLARE_ZONE_ID_BLTCDN", // Infrastructure management only
+      "CLOUDFLARE_ACCOUNT_ID", // Infrastructure management only
       "HETZNER_PROJECT_ID", // Infrastructure management only
       "S3_ENDPOINT", // Infrastructure configuration
       "BOLTFOUNDRY_COM_SERVER_IP", // Handled separately as server config


### PR DESCRIPTION

AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are needed at runtime for S3 asset
uploads. The application uses these credentials (or S3_ACCESS_KEY/S3_SECRET_KEY
as fallback) to upload assets to S3/R2 storage.

Previously these were incorrectly excluded as "handled separately" but they
need to be in .kamal/secrets for the deployed application to access S3.

This fixes the deployment error:
ERROR (Kamal::ConfigurationError): Secret 'S3_ACCESS_KEY' not found in .kamal/secrets

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/159).
* #160
* __->__ #159
* #157