### PR TITLE
Add /sl redirect handler for Sapling web interface in dev mode

### DIFF
--- a/apps/boltfoundry-com/apiRoutes.ts
+++ b/apps/boltfoundry-com/apiRoutes.ts
@@ -30,6 +30,54 @@ export function createApiRoutes(
       },
     },
     {
+      pattern: new URLPattern({ pathname: "/sl" }),
+      handler: async () => {
+        if (!serverInfo.isDev) {
+          return new Response("Not found", { status: 404 });
+        }
+
+        try {
+          const command = new Deno.Command("sl", {
+            args: ["web", "--json"],
+            stdout: "piped",
+            stderr: "piped",
+          });
+
+          const { stdout, stderr, code } = await command.output();
+
+          if (code !== 0) {
+            const errorText = new TextDecoder().decode(stderr);
+            console.error("Failed to get Sapling web info:", errorText);
+            return new Response("Failed to get Sapling web info", {
+              status: 500,
+            });
+          }
+
+          const outputText = new TextDecoder().decode(stdout);
+          const webInfo = JSON.parse(outputText);
+
+          // Get the URL from sl web and replace localhost with hostname.codebot.local
+          const hostname = Deno.hostname();
+          const saplingUrl = webInfo.url.replace(
+            "localhost",
+            `${hostname}.codebot.local`,
+          );
+
+          return new Response(null, {
+            status: 302,
+            headers: {
+              "Location": saplingUrl,
+            },
+          });
+        } catch (error) {
+          console.error("Error handling /sl redirect:", error);
+          return new Response("Error redirecting to Sapling web", {
+            status: 500,
+          });
+        }
+      },
+    },
+    {
       pattern: new URLPattern({ pathname: "/api/telemetry" }),
       handler: handleTelemetryRequest,
     },

--- a/infra/bft/tasks/dev.bft.ts
+++ b/infra/bft/tasks/dev.bft.ts
@@ -261,6 +261,14 @@ Examples:
     const hostname = Deno.hostname();
     ui.output(`Background server started on http://localhost:${port}`);
     ui.output(`Also available at http://${hostname}.codebot.local:${port}`);
+
+    // Add special URLs for boltfoundry-com
+    if (appName === "boltfoundry-com") {
+      ui.output(
+        `🟢 bft https://${hostname}.codebot.local / https://${hostname}.codebot.local/sl`,
+      );
+    }
+
     ui.output(`Logs are being written to tmp/${appName}-dev.log`);
     ui.output(
       `Use 'bft dev ${appName} --foreground' to run in foreground`,


### PR DESCRIPTION

- Add new route handler in boltfoundry-com that redirects /sl to Sapling web interface
- Handler runs 'sl web --json' to get the Sapling web URL with auth token and cwd
- Replaces localhost with hostname.codebot.local for proper proxy access
- Only works in development mode (returns 404 in production)
- Update dev.bft.ts to show /sl URL in statusline for boltfoundry-com
