### PR TITLE
Implement redirection for server and client

### DIFF
--- a/apps/boltfoundry-com/lib/BfIsographFragmentReader.tsx
+++ b/apps/boltfoundry-com/lib/BfIsographFragmentReader.tsx
@@ -5,6 +5,7 @@ import { getLogger } from "@bfmono/packages/logger/logger.ts";
 import { BfError } from "@bfmono/lib/BfError.ts";
 import type { RouteEntrypoint } from "../__generated__/builtRoutes.ts";
 import type { BfIsographEntrypoint } from "./BfIsographEntrypoint.ts";
+import { handleClientRedirect, isRedirect } from "./redirectHandler.ts";
 
 const _logger = getLogger(import.meta);
 
@@ -25,10 +26,20 @@ export function BfIsographFragmentReader<
     additionalProps?: Record<string, unknown>;
   },
 ): React.ReactNode {
-  const { Body } = useResult(
+  const result = useResult(
     props.fragmentReference,
     props.networkRequestOptions,
   );
+
+  // Check if this is a redirect response
+  if (isRedirect(result)) {
+    // Handle client-side redirect
+    handleClientRedirect(result.headers.Location);
+    // Return null while redirecting
+    return null;
+  }
+
+  const { Body } = result;
 
   if (!Body) {
     throw new BfError("Couldn't load a valid component");

--- a/apps/boltfoundry-com/lib/redirectHandler.test.ts
+++ b/apps/boltfoundry-com/lib/redirectHandler.test.ts
@@ -1,0 +1,313 @@
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  createServerRedirectResponse,
+  getRedirectFromEntrypoint,
+  handleClientRedirect,
+  isRedirect,
+} from "./redirectHandler.ts";
+
+Deno.test("redirectHandler", async (t) => {
+  await t.step("isRedirect - should identify valid redirect", () => {
+    const validRedirect = {
+      Body: null,
+      title: "Redirecting...",
+      status: 302,
+      headers: {
+        Location: "/new-path",
+      },
+    };
+
+    assertEquals(isRedirect(validRedirect), true);
+  });
+
+  await t.step("isRedirect - should reject non-redirect status codes", () => {
+    const notRedirect = {
+      Body: null,
+      title: "Page",
+      status: 200,
+      headers: {
+        Location: "/new-path",
+      },
+    };
+
+    assertEquals(isRedirect(notRedirect), false);
+  });
+
+  await t.step("isRedirect - should reject missing headers", () => {
+    const noHeaders = {
+      Body: null,
+      title: "Redirecting...",
+      status: 302,
+    };
+
+    assertEquals(isRedirect(noHeaders), false);
+  });
+
+  await t.step("isRedirect - should reject missing Location header", () => {
+    const noLocation = {
+      Body: null,
+      title: "Redirecting...",
+      status: 302,
+      headers: {},
+    };
+
+    assertEquals(isRedirect(noLocation), false);
+  });
+
+  await t.step("isRedirect - should reject null/undefined", () => {
+    assertEquals(isRedirect(null), false);
+    assertEquals(isRedirect(undefined), false);
+  });
+
+  await t.step("isRedirect - should reject non-objects", () => {
+    assertEquals(isRedirect("string"), false);
+    assertEquals(isRedirect(123), false);
+    assertEquals(isRedirect(true), false);
+  });
+
+  await t.step(
+    "createServerRedirectResponse - should create proper redirect response",
+    () => {
+      const response = createServerRedirectResponse("/redirect-path");
+
+      assertEquals(response.status, 302);
+      assertEquals(response.headers.get("Location"), "/redirect-path");
+      assertEquals(response.body, null);
+    },
+  );
+
+  await t.step(
+    "handleClientRedirect - should handle missing globalThis.location gracefully",
+    () => {
+      // Save original window
+      const originalWindow = globalThis.window;
+
+      try {
+        // Remove window (simulating server environment)
+        // deno-lint-ignore no-explicit-any
+        delete (globalThis as any).window;
+
+        // Should not throw
+        handleClientRedirect("/new-path");
+      } finally {
+        // Restore window
+        if (originalWindow) {
+          // deno-lint-ignore no-explicit-any
+          (globalThis as any).window = originalWindow;
+        }
+      }
+    },
+  );
+
+  await t.step(
+    "handleClientRedirect - should call location.replace when available",
+    () => {
+      // Save original window
+      const originalWindow = globalThis.window;
+
+      try {
+        // Mock window.location.replace
+        let replacedPath: string | undefined;
+        // deno-lint-ignore no-explicit-any
+        (globalThis as any).window = {
+          location: {
+            replace: (path: string) => {
+              replacedPath = path;
+            },
+          },
+        };
+
+        handleClientRedirect("/new-path");
+
+        assertEquals(replacedPath, "/new-path");
+      } finally {
+        // Restore window
+        if (originalWindow) {
+          // deno-lint-ignore no-explicit-any
+          (globalThis as any).window = originalWindow;
+        }
+      }
+    },
+  );
+
+  await t.step(
+    "getRedirectFromEntrypoint - should extract redirect from entrypoint",
+    () => {
+      // Mock entrypoint with redirect resolver
+      const mockEntrypoint = {
+        readerWithRefetchQueries: {
+          readerArtifact: {
+            resolver: () => ({
+              Body: null,
+              title: "Redirecting...",
+              status: 302,
+              headers: {
+                Location: "/pg/grade/decks",
+              },
+            }),
+          },
+        },
+      };
+
+      const redirect = getRedirectFromEntrypoint(mockEntrypoint);
+
+      assertExists(redirect);
+      assertEquals(redirect?.location, "/pg/grade/decks");
+    },
+  );
+
+  await t.step(
+    "getRedirectFromEntrypoint - should return null for non-redirect entrypoint",
+    () => {
+      // Mock entrypoint with normal resolver
+      const mockEntrypoint = {
+        readerWithRefetchQueries: {
+          readerArtifact: {
+            resolver: () => ({
+              Body: () => "Component",
+              title: "Page Title",
+            }),
+          },
+        },
+      };
+
+      const redirect = getRedirectFromEntrypoint(mockEntrypoint);
+
+      assertEquals(redirect, null);
+    },
+  );
+
+  await t.step(
+    "getRedirectFromEntrypoint - should handle missing resolver",
+    () => {
+      const mockEntrypoint = {
+        readerWithRefetchQueries: {
+          readerArtifact: {},
+        },
+      };
+
+      const redirect = getRedirectFromEntrypoint(mockEntrypoint);
+
+      assertEquals(redirect, null);
+    },
+  );
+
+  await t.step(
+    "getRedirectFromEntrypoint - should handle missing readerArtifact",
+    () => {
+      const mockEntrypoint = {
+        readerWithRefetchQueries: {},
+      };
+
+      const redirect = getRedirectFromEntrypoint(mockEntrypoint);
+
+      assertEquals(redirect, null);
+    },
+  );
+
+  await t.step(
+    "getRedirectFromEntrypoint - should handle missing readerWithRefetchQueries",
+    () => {
+      const mockEntrypoint = {};
+
+      const redirect = getRedirectFromEntrypoint(mockEntrypoint);
+
+      assertEquals(redirect, null);
+    },
+  );
+
+  await t.step(
+    "getRedirectFromEntrypoint - should handle resolver that throws",
+    () => {
+      const mockEntrypoint = {
+        readerWithRefetchQueries: {
+          readerArtifact: {
+            resolver: () => {
+              throw new Error("Resolver error");
+            },
+          },
+        },
+      };
+
+      // Should not throw, but return null
+      const redirect = getRedirectFromEntrypoint(mockEntrypoint);
+
+      assertEquals(redirect, null);
+    },
+  );
+
+  await t.step("Integration: Server-side redirect flow", () => {
+    // Simulate the full server-side flow
+    const mockEntrypoint = {
+      readerWithRefetchQueries: {
+        readerArtifact: {
+          resolver: () => ({
+            Body: null,
+            title: "Redirecting...",
+            status: 302,
+            headers: {
+              Location: "/dashboard",
+            },
+          }),
+        },
+      },
+    };
+
+    // 1. Check if entrypoint wants to redirect
+    const redirect = getRedirectFromEntrypoint(mockEntrypoint);
+
+    if (redirect) {
+      // 2. Create server response
+      const response = createServerRedirectResponse(redirect.location);
+
+      // 3. Verify response
+      assertEquals(response.status, 302);
+      assertEquals(response.headers.get("Location"), "/dashboard");
+    } else {
+      throw new Error("Expected redirect but got null");
+    }
+  });
+
+  await t.step("Integration: Client-side redirect flow", () => {
+    // Simulate the full client-side flow
+    const mockResult = {
+      Body: null,
+      title: "Redirecting...",
+      status: 302,
+      headers: {
+        Location: "/profile",
+      },
+    };
+
+    // 1. Check if result is a redirect
+    if (isRedirect(mockResult)) {
+      // 2. Mock window for testing
+      const originalWindow = globalThis.window;
+      let replacedPath: string | undefined;
+
+      try {
+        // deno-lint-ignore no-explicit-any
+        (globalThis as any).window = {
+          location: {
+            replace: (path: string) => {
+              replacedPath = path;
+            },
+          },
+        };
+
+        // 3. Handle the redirect
+        handleClientRedirect(mockResult.headers.Location);
+
+        // 4. Verify redirect was called
+        assertEquals(replacedPath, "/profile");
+      } finally {
+        if (originalWindow) {
+          // deno-lint-ignore no-explicit-any
+          (globalThis as any).window = originalWindow;
+        }
+      }
+    } else {
+      throw new Error("Expected redirect but isRedirect returned false");
+    }
+  });
+});

--- a/apps/boltfoundry-com/lib/redirectHandler.ts
+++ b/apps/boltfoundry-com/lib/redirectHandler.ts
@@ -1,0 +1,97 @@
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+import type { RouteEntrypoint } from "../__generated__/builtRoutes.ts";
+
+const logger = getLogger(import.meta);
+
+/**
+ * Checks if a RouteEntrypoint result is a redirect
+ */
+export function isRedirect(
+  result: unknown,
+): result is RouteEntrypoint & { status: 302; headers: { Location: string } } {
+  return (
+    result !== null &&
+    typeof result === "object" &&
+    "status" in result &&
+    result.status === 302 &&
+    "headers" in result &&
+    typeof (result as Record<string, unknown>).headers === "object" &&
+    (result as Record<string, unknown>).headers !== null &&
+    "Location" in
+      ((result as Record<string, unknown>).headers as Record<
+        string,
+        unknown
+      >) &&
+    typeof ((result as Record<string, unknown>).headers as Record<
+        string,
+        unknown
+      >).Location === "string"
+  );
+}
+
+/**
+ * Handles client-side redirects by updating the browser location
+ */
+export function handleClientRedirect(location: string): void {
+  // deno-lint-ignore no-window
+  if (typeof window !== "undefined" && window.location) {
+    logger.info(`Client-side redirect to: ${location}`);
+    // deno-lint-ignore no-window
+    window.location.replace(location);
+  }
+}
+
+/**
+ * Creates a server-side redirect Response
+ */
+export function createServerRedirectResponse(location: string): Response {
+  logger.info(`Server-side redirect to: ${location}`);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: location,
+    },
+  });
+}
+
+/**
+ * Attempts to get redirect information from an Isograph entrypoint
+ * without requiring full query data. Returns null if not a redirect.
+ */
+export function getRedirectFromEntrypoint(
+  entrypoint: unknown,
+): { location: string } | null {
+  try {
+    const entrypointObj = entrypoint as Record<string, unknown>;
+    const readerWithRefetchQueries = entrypointObj?.readerWithRefetchQueries as
+      | Record<string, unknown>
+      | undefined;
+    const readerArtifact = readerWithRefetchQueries?.readerArtifact as
+      | Record<string, unknown>
+      | undefined;
+    const resolver = readerArtifact?.resolver as
+      | ((data: unknown, props: unknown) => unknown)
+      | undefined;
+
+    if (!resolver) {
+      return null;
+    }
+
+    // Call resolver with minimal data to check for redirects
+    // This works for redirect-only entrypoints that don't need query data
+    const result = resolver(
+      { data: {}, parameters: {}, startUpdate: () => {} },
+      {},
+    );
+
+    if (isRedirect(result)) {
+      return { location: result.headers.Location };
+    }
+
+    return null;
+  } catch (error) {
+    // If we can't determine redirect status, return null
+    logger.debug(`Could not check redirect status:`, error);
+    return null;
+  }
+}

--- a/memos/2-areas/developer-guides/isograph-patterns.md
+++ b/memos/2-areas/developer-guides/isograph-patterns.md
@@ -1,0 +1,358 @@
+# Isograph Patterns and Best Practices
+
+## Core Philosophy
+
+Isograph follows a "resolvers all the way down" pattern where components are
+self-contained and fetch their own data. This guide documents the patterns we
+use at Bolt Foundry.
+
+## External Resources
+
+### Official Documentation
+
+- [Isograph Documentation](https://isograph.dev/) - Official docs
+- [Quickstart Guide](https://isograph.dev/docs/quickstart/) - Getting started
+- [Introduction](https://isograph.dev/docs/introduction/) - Core concepts
+- [Blog](https://isograph.dev/blog/) - Latest updates and deep dives
+
+### Examples and Demos
+
+- [Isograph GitHub Repository](https://github.com/isographlabs/isograph) -
+  Source code and examples
+- Pokemon Vite Demo - Check the `/demos` directory in the main repo for Vite
+  configuration examples
+- [Quickstart Repository](https://github.com/isographlabs/quickstart) - Simple
+  example app
+
+### Key Concepts from Docs
+
+- **Data Masking**: Components don't see each other's data
+- **Automatic Query Generation**: Compiler generates GraphQL queries
+- **Client Fields**: Components defined as fields on GraphQL types
+- **Loadable Fields**: Lazy-loading with `@loadable` directive
+
+## 1. Component Independence
+
+### ❌ Anti-Pattern: Prop Drilling
+
+```typescript
+// Parent fetches all data and passes down
+export const Parent = iso(`
+  field Query.Parent @component {
+    organization {
+      decks { ... }
+      samples { ... }
+      graders { ... }
+    }
+  }
+`)(function Parent({ data }) {
+  return <Child decks={data.decks} samples={data.samples} />;
+});
+```
+
+### ✅ Pattern: Self-Contained Components
+
+```typescript
+// Each component fetches only what it needs
+export const Parent = iso(`
+  field Query.Parent @component {
+    organization {
+      ChildComponent  // Reference to child component
+    }
+  }
+`)(function Parent({ data }) {
+  const ChildComponent = data.organization.ChildComponent;
+  return <ChildComponent />;
+});
+```
+
+## 2. Routing Architecture
+
+### Separate Entrypoints Pattern
+
+Instead of one monolithic entrypoint with internal routing, create separate
+entrypoints for each major route:
+
+```typescript
+// routes.ts
+export const isographAppRoutes = new Map([
+  ["/pg/grade/*", entrypointGrade], // Grade entrypoint
+  ["/pg/analyze", entrypointAnalyze], // Analyze entrypoint
+  ["/pg/chat", entrypointChat], // Chat entrypoint
+]);
+
+// EntrypointGrade.ts
+export const EntrypointGrade = iso(`
+  field Query.EntrypointGrade {
+    Grade
+  }
+`)(function EntrypointGrade({ data }) {
+  const Body = data.Grade;
+  return { Body, title: "Grade - Bolt Foundry" };
+});
+```
+
+**Benefits:**
+
+- Better code splitting (only load what's needed)
+- True component independence
+- No complex routing logic inside components
+- Cleaner architecture
+
+## 3. Component Hierarchy Pattern
+
+For list views, use a three-level hierarchy:
+
+```typescript
+// Level 1: View Component (on Organization)
+export const DecksView = iso(`
+  field Organization.DecksView @component {
+    DeckList
+  }
+`)(function DecksView({ data }) {
+  return (
+    <div className="decks-view">
+      <h2>Decks</h2>
+      <data.DeckList />
+    </div>
+  );
+});
+
+// Level 2: List Component (on Organization)
+export const DeckList = iso(`
+  field Organization.DeckList @component {
+    decks(first: 100) {
+      edges {
+        node {
+          DecksListItem  // Reference to item component
+        }
+      }
+    }
+  }
+`)(function DeckList({ data }) {
+  const items = data.decks?.edges?.map((edge) => edge.node.DecksListItem) || [];
+  return (
+    <div className="decks-list">
+      {items.map((Item, i) => <Item key={i} />)}
+    </div>
+  );
+});
+
+// Level 3: Item Component (on the entity type)
+export const DecksListItem = iso(`
+  field BfDeck.DecksListItem @component {
+    id
+    name
+    description
+  }
+`)(function DecksListItem({ data }) {
+  return (
+    <div className="deck-item">
+      <h4>{data.name}</h4>
+      <p>{data.description}</p>
+    </div>
+  );
+});
+```
+
+## 4. Naming Conventions
+
+### Component Fields
+
+- Use descriptive names that indicate the component's purpose
+- For list items, use plural form: `DecksListItem` not `DeckListItem`
+- For views, append `View`: `DecksView`, `AnalyzeView`
+
+### File Organization
+
+```
+components/
+  Grade.tsx           # Top-level route component
+  DecksView.tsx       # View component (field on Organization)
+  DeckList.tsx        # List component (field on Organization)
+  DecksListItem.tsx   # Item component (field on BfDeck)
+entrypoints/
+  EntrypointGrade.ts  # Route entrypoint
+```
+
+## 5. Data Fetching
+
+### Fetch Only What You Need
+
+```typescript
+// ❌ Bad: Fetching unused fields
+field Organization.DeckList @component {
+  decks(first: 100) {
+    edges {
+      node {
+        id
+        name
+        description
+        samples { ... }  # Not needed for list view
+        graders { ... }  # Not needed for list view
+      }
+    }
+  }
+}
+
+// ✅ Good: Minimal data for the view
+field Organization.DeckList @component {
+  decks(first: 100) {
+    edges {
+      node {
+        DecksListItem  # Item component fetches what it needs
+      }
+    }
+  }
+}
+```
+
+## 6. Navigation Pattern
+
+Handle navigation at the lowest level possible:
+
+```typescript
+export const DecksListItem = iso(`
+  field BfDeck.DecksListItem @component {
+    id
+    name
+  }
+`)(function DecksListItem({ data }) {
+  const { navigate } = useRouter();
+
+  const handleClick = () => {
+    navigate(`/pg/grade/decks/${data.id}`);
+  };
+
+  return (
+    <div onClick={handleClick}>
+      {data.name}
+    </div>
+  );
+});
+```
+
+## 7. Empty States
+
+Handle empty states at the appropriate level:
+
+```typescript
+export const DeckList = iso(`
+  field Organization.DeckList @component {
+    decks(first: 100) {
+      edges {
+        node {
+          DecksListItem
+        }
+      }
+    }
+  }
+`)(function DeckList({ data }) {
+  const items = data.decks?.edges?.map((edge) => edge.node.DecksListItem) || [];
+
+  if (items.length === 0) {
+    return (
+      <BfDsEmptyState
+        icon="deck"
+        title="No decks yet"
+        description="Create your first deck to get started"
+      />
+    );
+  }
+
+  return (
+    <div className="decks-list">
+      {items.map((Item, i) => <Item key={i} />)}
+    </div>
+  );
+});
+```
+
+## 8. Type Safety
+
+The Isograph compiler generates types, but you can add additional type safety:
+
+```typescript
+import type { DecksListItem as DecksListItemType } from "./__generated__/DecksListItem";
+
+export const DecksListItem = iso(`
+  field BfDeck.DecksListItem @component {
+    id
+    name
+  }
+`)(function DecksListItem({ data }: { data: DecksListItemType }) {
+  // TypeScript now knows the shape of data
+  return <div>{data.name}</div>;
+});
+```
+
+## 9. Feature Flags and Progressive Enhancement
+
+When migrating or adding features, use feature flags:
+
+```typescript
+export const DeckList = iso(`
+  field Organization.DeckList @component {
+    decks(first: 100) { ... }
+  }
+`)(function DeckList({ data }) {
+  const enableSearch = false; // Feature flag
+
+  return (
+    <>
+      {enableSearch && <SearchBar />}
+      <div className="decks-list">
+        {/* list items */}
+      </div>
+    </>
+  );
+});
+```
+
+## 10. Testing Considerations
+
+Isograph components are easier to test because they're self-contained:
+
+```typescript
+// Each component can be tested in isolation
+// Mock only the data it directly uses
+const mockData = {
+  decks: {
+    edges: [
+      { node: { DecksListItem: MockDecksListItem } },
+    ],
+  },
+};
+```
+
+## Common Pitfalls to Avoid
+
+1. **Don't pass data between Isograph components** - Let each fetch its own
+2. **Don't create "UI-only" wrapper components** - Make them Isograph components
+3. **Don't fetch data you won't use** - Be minimal
+4. **Don't handle routing at high levels** - Push it down to where the action
+   happens
+5. **Don't forget to run `bft iso`** - The compiler needs to generate the
+   queries
+
+## Migration Strategy
+
+When converting existing components:
+
+1. Start from the leaves (list items)
+2. Work your way up to containers
+3. Finally update the entrypoints
+4. Keep feature flags for gradual rollout
+5. Remove prop drilling as you go
+
+## Summary
+
+The key insight is that Isograph components should be:
+
+- **Self-contained**: Fetch their own data
+- **Composable**: Reference other components as fields
+- **Minimal**: Only fetch what they need
+- **Independent**: No prop passing between components
+
+This creates a cleaner, more maintainable architecture that scales well with
+application complexity.


### PR DESCRIPTION

- Created unified redirect handler module for both server and client-side redirects
- Fixed TypeScript type errors by removing 'any' types
- Added comprehensive unit tests for redirect functionality
- Refactored server.tsx and BfIsographFragmentReader.tsx to use the new handler
- Supports redirect entrypoints that return status 302 with Location header

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/173).
* #190
* #183
* #182
* #180
* __->__ #173
* #171