### PR TITLE
feat(bft): add bfdb command for direct SQLite database queries

### DIFF
--- a/infra/bft/tasks/__tests__/bfdb.test.ts
+++ b/infra/bft/tasks/__tests__/bfdb.test.ts
@@ -1,0 +1,67 @@
+import { getConfigurationVariable } from "@bolt-foundry/get-configuration-var";
+import { assertEquals, assertExists } from "@std/assert";
+import { bftDefinition } from "../bfdb.bft.ts";
+import { ui } from "@bfmono/packages/tui/tui.ts";
+
+Deno.test("bfdb command - smoke test for file existence", () => {
+  // Just verify the function exists and is callable
+  assertExists(bftDefinition);
+  assertExists(bftDefinition.fn);
+  assertEquals(typeof bftDefinition.fn, "function");
+});
+
+Deno.test("bfdb command - validates query argument", () => {
+  // Capture ui output
+  const originalError = ui.error;
+  const originalOutput = ui.output;
+
+  let errorOutput = "";
+  let _logOutput = "";
+
+  ui.error = (msg: string) => {
+    errorOutput = msg;
+  };
+  ui.output = (msg: string) => {
+    _logOutput = msg;
+  };
+
+  const exitCode = bftDefinition.fn([]);
+
+  // Restore originals
+  ui.error = originalError;
+  ui.output = originalOutput;
+
+  // Verify error handling
+  assertEquals(errorOutput, "Error: --query or -q argument is required");
+  assertEquals(exitCode, 1);
+});
+
+Deno.test("bfdb command - handles non-existent database gracefully", () => {
+  // Create a temp test database path that doesn't exist
+  const testDbPath = `tmp/test-nonexistent-${Date.now()}.sqlite`;
+
+  // Set environment variable for test
+  const originalEnv = getConfigurationVariable("SQLITE_DB_PATH");
+  Deno.env.set("SQLITE_DB_PATH", testDbPath);
+
+  const originalError = ui.error;
+
+  let _errorOutput = "";
+
+  ui.error = (msg: string) => {
+    _errorOutput = msg;
+  };
+
+  const exitCode = bftDefinition.fn(["--query", "SELECT 1"]);
+
+  // Restore
+  ui.error = originalError;
+  if (originalEnv) {
+    Deno.env.set("SQLITE_DB_PATH", originalEnv);
+  } else {
+    Deno.env.delete("SQLITE_DB_PATH");
+  }
+
+  // Should fail gracefully
+  assertEquals(exitCode, 1);
+});

--- a/infra/bft/tasks/bfdb.bft.ts
+++ b/infra/bft/tasks/bfdb.bft.ts
@@ -1,0 +1,69 @@
+import { DatabaseSync } from "sqlite";
+import { getConfigurationVariable } from "@bolt-foundry/get-configuration-var";
+import type { TaskDefinition } from "../bft.ts";
+import { ui } from "@bfmono/packages/tui/tui.ts";
+
+const usage = `
+Usage: bft bfdb --query "SELECT * FROM nodes LIMIT 10"
+       bft bfdb -q "SELECT COUNT(*) FROM nodes"
+
+Options:
+  --query, -q  SQL query to execute
+`;
+
+function bfdb(args: Array<string>): number {
+  // Parse arguments
+  let query: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--query" || args[i] === "-q") {
+      query = args[i + 1];
+      i++;
+    }
+  }
+
+  if (!query) {
+    ui.error("Error: --query or -q argument is required");
+    ui.output(usage);
+    return 1;
+  }
+
+  // Get database path (same logic as BfDb)
+  const customDbPath = getConfigurationVariable("SQLITE_DB_PATH");
+  const dbPath = customDbPath || "tmp/bfdb.sqlite";
+
+  try {
+    // Open database in read-only mode for safety
+    const db = new DatabaseSync(dbPath, {
+      readOnly: true,
+    });
+
+    // Execute query
+    const rows = db.prepare(query).all();
+
+    // Pretty print results
+    if (rows.length > 0) {
+      // deno-lint-ignore no-console
+      console.table(rows);
+    } else {
+      ui.output("No results found");
+    }
+
+    db.close();
+  } catch (error) {
+    ui.error(
+      `Database query failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return 1;
+  }
+
+  return 0;
+}
+
+// Export the task definition for autodiscovery
+export const bftDefinition = {
+  description: "Query BfDb SQLite database directly",
+  fn: bfdb,
+} satisfies TaskDefinition;


### PR DESCRIPTION

Adds a new 'bft bfdb' command that enables direct SQL queries against the BfDb SQLite database. This is useful for introspecting the database contents and debugging data issues from the command line.

Features:
- Execute arbitrary SQL queries with --query/-q flag
- Opens database in read-only mode for safety
- Respects SQLITE_DB_PATH env var or defaults to tmp/bfdb.sqlite
- Pretty-prints results using console.table
- Includes comprehensive smoke tests

Usage:
  bft bfdb --query "SELECT * FROM nodes LIMIT 10"
  bft bfdb -q "SELECT COUNT(*) FROM nodes"
