### PR TITLE
Fix mouse movement jitter in E2E test video recordings

### DIFF
--- a/infra/testing/video-recording/cursor-overlay-page-injection.ts
+++ b/infra/testing/video-recording/cursor-overlay-page-injection.ts
@@ -61,10 +61,23 @@ const CURSOR_SCRIPT = `
   let mouseX = window.__mousePosition ? window.__mousePosition.x : window.innerWidth / 2;
   let mouseY = window.__mousePosition ? window.__mousePosition.y : window.innerHeight / 2;
 
+  // Use requestAnimationFrame for smoother updates
+  let animationFrameId = null;
+  
   document.addEventListener("mousemove", (e) => {
     mouseX = e.clientX;
     mouseY = e.clientY;
-    updateCursorPosition();
+    
+    // Cancel any pending animation frame
+    if (animationFrameId) {
+      cancelAnimationFrame(animationFrameId);
+    }
+    
+    // Schedule update on next animation frame for smoother rendering
+    animationFrameId = requestAnimationFrame(() => {
+      updateCursorPosition();
+      animationFrameId = null;
+    });
   });
 
   function updateCursorPosition() {

--- a/infra/testing/video-recording/smooth-ui.ts
+++ b/infra/testing/video-recording/smooth-ui.ts
@@ -100,35 +100,27 @@ const RECORDING_THROBBER_SCRIPT = `
     document.head.appendChild(style);
     document.body.appendChild(throbber);
 
-    // Function to attach throbber to cursor
-    function attachThrobberToCursor() {
-      const cursor = document.getElementById("e2e-cursor-overlay");
+    // Function to update throbber position based on global mouse position
+    function updateThrobberPosition() {
       const throbber = document.getElementById("recording-throbber");
-
-      if (cursor && throbber) {
-        const cursorRect = cursor.getBoundingClientRect();
-        throbber.style.left = cursorRect.left + cursorRect.width / 2 + "px";
-        throbber.style.top = cursorRect.top + cursorRect.height / 2 + "px";
+      const mousePos = globalThis.__mousePosition;
+      
+      if (throbber && mousePos) {
+        // Position throbber directly at mouse position
+        throbber.style.left = mousePos.x + "px";
+        throbber.style.top = mousePos.y + "px";
       }
     }
 
-    // Attach throbber to cursor position initially
-    attachThrobberToCursor();
+    // Initial positioning
+    updateThrobberPosition();
 
-    // Update throbber position when cursor moves
-    const updateThrobberPosition = () => {
-      attachThrobberToCursor();
-    };
-
-    // Listen for mouse movement to update throbber position
-    document.addEventListener("mousemove", updateThrobberPosition);
-
-    // Also update position periodically in case cursor moves programmatically
-    const positionInterval = setInterval(updateThrobberPosition, 100);
+    // Update position periodically to catch programmatic mouse movements
+    // Using a longer interval to reduce jitter
+    const positionInterval = setInterval(updateThrobberPosition, 250);
 
     // Store cleanup function
     globalThis.__cleanupRecordingThrobber = () => {
-      document.removeEventListener("mousemove", updateThrobberPosition);
       clearInterval(positionInterval);
     };
   })();


### PR DESCRIPTION

- Add convenience methods to E2ETestContext for cleaner test API
  - getPageTitle, getPageUrl, getPageCookies, getPageContent
  - waitForNetworkIdle, waitForSelector, click, goto, waitForFunction
  - type method now uses smoothType for better visual feedback

- Fix race condition in recording throbber positioning
  - Remove redundant mousemove listener that caused jitter
  - Simplify to use only global mouse position with longer interval (250ms)
  - Throbber now follows mouse position directly instead of cursor element

- Improve cursor overlay rendering performance
  - Use requestAnimationFrame for smooth cursor position updates
  - Synchronize updates with browser repaints to reduce visual artifacts

These changes result in smoother mouse movement in test recordings
and provide a cleaner API for writing E2E tests.
