### PR TITLE
Add E2E context convenience methods with cleaner naming

### DIFF
--- a/apps/boltfoundry-com/__tests__/e2e/auth-progress.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/auth-progress.test.e2e.ts
@@ -101,7 +101,7 @@ Deno.test("🎬 Frontend Authentication Implementation Progress", async (t) => {
         await navigateTo(context, "/rlhf");
         await context.waitForNetworkIdle({ timeout: 3000 });
 
-        const currentUrl = context.url();
+        const currentUrl = context.getPageUrl();
         const wasRedirectedToLogin = currentUrl.includes("/login");
         const stayedOnProtectedRoute = currentUrl.includes("/rlhf");
 
@@ -175,7 +175,7 @@ Deno.test("🎬 Frontend Authentication Implementation Progress", async (t) => {
           await new Promise((resolve) => setTimeout(resolve, 1000));
 
           // Check if login was successful or if we got an error
-          const currentUrl = context.url();
+          const currentUrl = context.getPageUrl();
           logger.info(`📍 Current URL after login attempt: ${currentUrl}`);
 
           // Verify authentication by checking cookies
@@ -240,7 +240,7 @@ Deno.test("🎬 Frontend Authentication Implementation Progress", async (t) => {
         await navigateTo(context, "/rlhf");
         await context.waitForNetworkIdle({ timeout: 3000 });
 
-        const currentUrl = context.url();
+        const currentUrl = context.getPageUrl();
         const stayedOnProtectedRoute = currentUrl.includes("/rlhf");
         const wasRedirectedToLogin = currentUrl.includes("/login");
 

--- a/apps/boltfoundry-com/__tests__/e2e/eval.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/eval.test.e2e.ts
@@ -63,7 +63,7 @@ Deno.test("Eval page functionality", async (t) => {
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
       // Verify we're on the login page
-      const currentUrl = context.url();
+      const currentUrl = context.getPageUrl();
       assert(
         currentUrl.includes("/login"),
         `Should be on login page, but URL is ${currentUrl}`,
@@ -107,7 +107,7 @@ Deno.test("Eval page functionality", async (t) => {
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
       // Check if we were redirected or if there's an auth cookie
-      const currentUrl = context.url();
+      const currentUrl = context.getPageUrl();
       logger.debug(`Current URL after auth: ${currentUrl}`);
 
       const cookies = await context.__UNSAFE_page_useContextMethodsInstead

--- a/apps/boltfoundry-com/__tests__/e2e/homepage.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/homepage.test.e2e.ts
@@ -19,7 +19,7 @@ Deno.test("Homepage loads successfully", async () => {
     await new Promise((resolve) => setTimeout(resolve, 3000));
 
     // Basic assertions to verify the page loaded
-    const title = await context.title();
+    const title = await context.getPageTitle();
     logger.info("Page title:", title);
 
     // Verify we're on the right page

--- a/apps/boltfoundry-com/__tests__/e2e/hud.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/hud.test.e2e.ts
@@ -50,7 +50,7 @@ Deno.test("HUD functionality", async (t) => {
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
       // Verify we're on the login page
-      const currentUrl = context.url();
+      const currentUrl = context.getPageUrl();
       assert(
         currentUrl.includes("/login"),
         `Should be on login page, but URL is ${currentUrl}`,
@@ -70,7 +70,7 @@ Deno.test("HUD functionality", async (t) => {
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
       // Verify we were redirected to /pg (eval routes start with /pg)
-      const authUrl = context.url();
+      const authUrl = context.getPageUrl();
       assert(
         authUrl.includes("/pg"),
         `Should be redirected to /pg after authentication, but was redirected to ${authUrl}`,

--- a/apps/boltfoundry-com/__tests__/e2e/login-interactive-demo.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/login-interactive-demo.test.e2e.ts
@@ -180,7 +180,7 @@ Deno.test("🎬 Interactive Login Demo - Production Mode", async () => {
     await showSubtitle("🎉 Authentication successful!");
 
     // Check if we were redirected or if there's an auth cookie
-    const currentUrl = context.url();
+    const currentUrl = context.getPageUrl();
     logger.info(`Current URL after auth: ${currentUrl}`);
 
     const cookies = await context.__UNSAFE_page_useContextMethodsInstead

--- a/apps/boltfoundry-com/__tests__/e2e/rlhf.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/rlhf.test.e2e.ts
@@ -37,18 +37,18 @@ Deno.test("RLHF page shows login when not authenticated", async () => {
 
     // Check that page loaded successfully (no 404)
     const response = await context.navigate(
-      context.url(),
+      context.getPageUrl(),
     );
     const statusCode = response?.status();
     logger.info("HTTP Status Code:", statusCode);
 
     logger.info(
       "Page title:",
-      await context.title(),
+      await context.getPageTitle(),
     );
     logger.info(
       "Page URL:",
-      context.url(),
+      context.getPageUrl(),
     );
 
     // Extract just the body content for debugging

--- a/apps/boltfoundry-com/__tests__/e2e/ssr.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/ssr.test.e2e.ts
@@ -30,13 +30,13 @@ Deno.test("SSR landing page loads and hydrates correctly", async () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // Check current URL after navigation
-    const currentUrl = context.url();
+    const currentUrl = context.getPageUrl();
     logger.info(`Current URL after button click: ${currentUrl}`);
 
     // Remove manual screenshot - let video recording capture naturally
 
     // Wait for content to ensure page loaded
-    const title = await context.title();
+    const title = await context.getPageTitle();
     logger.info(`Page title: ${title}`);
 
     // Verify the page title is correct

--- a/apps/boltfoundry-com/__tests__/e2e/ui-route.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/ui-route.test.e2e.ts
@@ -22,11 +22,11 @@ Deno.test("UI route renders UIDemo component correctly", async () => {
     await navigateTo(context, "/ui");
 
     // Wait for content to ensure page loaded
-    const title = await context.title();
+    const title = await context.getPageTitle();
     logger.info(`UI page title: ${title}`);
 
     // Check the current URL
-    const currentUrl = context.url();
+    const currentUrl = context.getPageUrl();
     logger.info(`Current URL: ${currentUrl}`);
 
     // Check the environment and routing state

--- a/infra/testing/e2e/setup.ts
+++ b/infra/testing/e2e/setup.ts
@@ -132,8 +132,11 @@ export interface E2ETestContext {
     // deno-lint-ignore no-explicit-any
     ...args: Array<any>
   ) => Promise<T>;
-  url: () => string;
-  title: () => Promise<string>;
+  // Page information getters with descriptive names
+  getPageUrl: () => string;
+  getPageTitle: () => Promise<string>;
+  getPageCookies: () => Promise<Array<any>>;
+  getPageContent: () => Promise<string>;
   waitForNetworkIdle: (options?: {
     timeout?: number;
     idleTime?: number;
@@ -752,11 +755,17 @@ export async function setupE2ETest(options: {
       ): Promise<T> => {
         return await page.evaluate(fn, ...args);
       },
-      url: (): string => {
+      getPageUrl: (): string => {
         return page.url();
       },
-      title: async (): Promise<string> => {
+      getPageTitle: async (): Promise<string> => {
         return await page.title();
+      },
+      getPageCookies: async (): Promise<Array<any>> => {
+        return await page.cookies();
+      },
+      getPageContent: async (): Promise<string> => {
+        return await page.content();
       },
       waitForNetworkIdle: async (options?: {
         timeout?: number;

--- a/infra/testing/video-recording/cursor-overlay-page-injection.ts
+++ b/infra/testing/video-recording/cursor-overlay-page-injection.ts
@@ -61,10 +61,23 @@ const CURSOR_SCRIPT = `
   let mouseX = window.__mousePosition ? window.__mousePosition.x : window.innerWidth / 2;
   let mouseY = window.__mousePosition ? window.__mousePosition.y : window.innerHeight / 2;
 
+  // Use requestAnimationFrame for smoother updates
+  let animationFrameId = null;
+  
   document.addEventListener("mousemove", (e) => {
     mouseX = e.clientX;
     mouseY = e.clientY;
-    updateCursorPosition();
+    
+    // Cancel any pending animation frame
+    if (animationFrameId) {
+      cancelAnimationFrame(animationFrameId);
+    }
+    
+    // Schedule update on next animation frame for smoother rendering
+    animationFrameId = requestAnimationFrame(() => {
+      updateCursorPosition();
+      animationFrameId = null;
+    });
   });
 
   function updateCursorPosition() {

--- a/infra/testing/video-recording/smooth-ui.ts
+++ b/infra/testing/video-recording/smooth-ui.ts
@@ -100,35 +100,27 @@ const RECORDING_THROBBER_SCRIPT = `
     document.head.appendChild(style);
     document.body.appendChild(throbber);
 
-    // Function to attach throbber to cursor
-    function attachThrobberToCursor() {
-      const cursor = document.getElementById("e2e-cursor-overlay");
+    // Function to update throbber position based on global mouse position
+    function updateThrobberPosition() {
       const throbber = document.getElementById("recording-throbber");
-
-      if (cursor && throbber) {
-        const cursorRect = cursor.getBoundingClientRect();
-        throbber.style.left = cursorRect.left + cursorRect.width / 2 + "px";
-        throbber.style.top = cursorRect.top + cursorRect.height / 2 + "px";
+      const mousePos = globalThis.__mousePosition;
+      
+      if (throbber && mousePos) {
+        // Position throbber directly at mouse position
+        throbber.style.left = mousePos.x + "px";
+        throbber.style.top = mousePos.y + "px";
       }
     }
 
-    // Attach throbber to cursor position initially
-    attachThrobberToCursor();
+    // Initial positioning
+    updateThrobberPosition();
 
-    // Update throbber position when cursor moves
-    const updateThrobberPosition = () => {
-      attachThrobberToCursor();
-    };
-
-    // Listen for mouse movement to update throbber position
-    document.addEventListener("mousemove", updateThrobberPosition);
-
-    // Also update position periodically in case cursor moves programmatically
-    const positionInterval = setInterval(updateThrobberPosition, 100);
+    // Update position periodically to catch programmatic mouse movements
+    // Using a longer interval to reduce jitter
+    const positionInterval = setInterval(updateThrobberPosition, 250);
 
     // Store cleanup function
     globalThis.__cleanupRecordingThrobber = () => {
-      document.removeEventListener("mousemove", updateThrobberPosition);
       clearInterval(positionInterval);
     };
   })();


### PR DESCRIPTION

- Add getPageUrl, getPageTitle, getPageCookies, getPageContent methods
- Remove backwards compatibility aliases for cleaner API
- Update all existing tests to use new method names
- Provides more descriptive API for E2E tests
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/185).
* #196
* #193
* #192
* #189
* #188
* #187
* __->__ #185
* #184