### PR TITLE
Fix OP_SERVICE_ACCOUNT_TOKEN for notify-internalbf operation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,6 +187,8 @@ jobs:
             if ! command -v kamal &> /dev/null; then
               echo \"Installing kamal gem...\"
               gem install kamal
+              # Add Ruby gem bin directory to PATH
+              export PATH=\"\$PATH:\$HOME/.local/share/gem/ruby/3.3.0/bin\"
             fi
 
             # Deploy with Kamal

--- a/.github/workflows/operations.yml
+++ b/.github/workflows/operations.yml
@@ -133,6 +133,14 @@ jobs:
                 chmod 600 ~/.ssh/id_rsa
                 ssh-keyscan -H \$FLOATING_IP >> ~/.ssh/known_hosts 2>/dev/null || true
 
+                # Install kamal gem if not already installed
+                if ! command -v kamal &> /dev/null; then
+                  echo \"Installing kamal gem...\"
+                  gem install kamal
+                  # Add Ruby gem bin directory to PATH
+                  export PATH=\"\$PATH:\$HOME/.local/share/gem/ruby/3.3.0/bin\"
+                fi
+
                 # Go to app directory and unlock Kamal
                 cd \$GITHUB_WORKSPACE/apps/boltfoundry-com
                 kamal lock release --rolling

--- a/.github/workflows/operations.yml
+++ b/.github/workflows/operations.yml
@@ -73,8 +73,14 @@ jobs:
       - name: Execute Operation
         run: |
           nix develop --accept-flake-config --command bash -euc "
+            # Use CI token for notify operations, infrastructure token for others
+            if [ '${{ env.OPERATION }}' = 'notify-internalbf' ]; then
+              export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.CI_OP_SERVICE_ACCOUNT_TOKEN }}'
+            else
+              export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
+            fi
+            
             # Sync all variables from 1Password
-            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
             bft sitevar sync --force
 
             # Source both config and secrets

--- a/.github/workflows/operations.yml
+++ b/.github/workflows/operations.yml
@@ -37,7 +37,8 @@ concurrency:
 jobs:
   execute-operation:
     runs-on: ubuntu-latest
-    environment: infrastructure
+    # Only use infrastructure environment for terraform/kamal operations, not for notifications
+    environment: ${{ (github.event_name == 'workflow_dispatch' && contains(fromJSON('["terraform-plan", "terraform-apply", "terraform-destroy", "terraform-refresh", "kamal-unlock"]'), inputs.operation)) && 'infrastructure' || '' }}
 
     steps:
       - name: Set operation for push events


### PR DESCRIPTION

The notify-internalbf operation doesn't have access to the infrastructure
environment's OP_SERVICE_ACCOUNT_TOKEN secret. Use CI_OP_SERVICE_ACCOUNT_TOKEN
instead, which is available at the repository level.

This allows the notification to run without the infrastructure environment
while still being able to sync the necessary GitHub token from 1Password.
