### PR TITLE
Fix GitHub Actions workflow failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,6 +187,8 @@ jobs:
             if ! command -v kamal &> /dev/null; then
               echo \"Installing kamal gem...\"
               gem install kamal
+              # Add Ruby gem bin directory to PATH
+              export PATH=\"\$PATH:\$HOME/.local/share/gem/ruby/3.3.0/bin\"
             fi
 
             # Deploy with Kamal

--- a/.github/workflows/operations.yml
+++ b/.github/workflows/operations.yml
@@ -133,6 +133,14 @@ jobs:
                 chmod 600 ~/.ssh/id_rsa
                 ssh-keyscan -H \$FLOATING_IP >> ~/.ssh/known_hosts 2>/dev/null || true
 
+                # Install kamal gem if not already installed
+                if ! command -v kamal &> /dev/null; then
+                  echo \"Installing kamal gem...\"
+                  gem install kamal
+                  # Add Ruby gem bin directory to PATH
+                  export PATH=\"\$PATH:\$HOME/.local/share/gem/ruby/3.3.0/bin\"
+                fi
+
                 # Go to app directory and unlock Kamal
                 cd \$GITHUB_WORKSPACE/apps/boltfoundry-com
                 kamal lock release --rolling


### PR DESCRIPTION

- Fix kamal PATH issue in deploy.yml by installing gem and adding to PATH
- Fix kamal PATH issue in operations.yml kamal-unlock operation
- Fix repository URL from boltfoundryinc/internalbf to bolt-foundry/internalbf
- Fixes workflow runs 17112804875 and 17112804888
