### PR TITLE
Fix container certificate path for automatic HTTPS proxy startup

### DIFF
--- a/.github/workflows/operations.yml
+++ b/.github/workflows/operations.yml
@@ -73,8 +73,14 @@ jobs:
       - name: Execute Operation
         run: |
           nix develop --accept-flake-config --command bash -euc "
+            # Use CI token for notify operations, infrastructure token for others
+            if [ '${{ env.OPERATION }}' = 'notify-internalbf' ]; then
+              export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.CI_OP_SERVICE_ACCOUNT_TOKEN }}'
+            else
+              export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
+            fi
+
             # Sync all variables from 1Password
-            export OP_SERVICE_ACCOUNT_TOKEN='${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
             bft sitevar sync --force
 
             # Source both config and secrets

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "deno.enable": true
+  "deno.enable": true,
+  "markdown.styles": ["styles/markdown-custom.css"]
 }

--- a/apps/boltfoundry-com/__tests__/e2e/fastpitch-telemetry.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/fastpitch-telemetry.test.e2e.ts
@@ -13,12 +13,11 @@ Deno.test("Fastpitch telemetry to dashboard flow", async (t) => {
 
   try {
     // Start video recording
-    const { stop, showSubtitle } = await context.startRecording(
+    const { stop, showSubtitle, showTitleCard } = await context.startRecording(
       "fastpitch-telemetry-test",
     );
 
-    await showSubtitle("🚀 Fastpitch Telemetry Test");
-    await new Promise((resolve) => setTimeout(resolve, 3000));
+    await showTitleCard("Fastpitch Telemetry Test", "E2E Demo Video");
 
     await t.step("Login and create organization", async () => {
       // Navigate to homepage
@@ -35,8 +34,8 @@ Deno.test("Fastpitch telemetry to dashboard flow", async (t) => {
       );
       await context.click('a[href="/login"]');
 
-      // Wait for login page
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // Wait for login page to load
+      await context.waitForNetworkIdle({ timeout: 2000 });
       assert(
         context.url().includes("/login"),
         "Should be on login page",
@@ -49,8 +48,8 @@ Deno.test("Fastpitch telemetry to dashboard flow", async (t) => {
       );
       await context.click("#google-signin-button");
 
-      // Wait for authentication
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      // Wait for authentication to complete
+      await context.waitForNetworkIdle({ timeout: 3000 });
 
       // Verify redirected to /pg
       assert(
@@ -59,12 +58,10 @@ Deno.test("Fastpitch telemetry to dashboard flow", async (t) => {
       );
 
       await showSubtitle("✅ Logged in successfully");
-      await new Promise((resolve) => setTimeout(resolve, 3000));
     });
 
     await t.step("Generate telemetry with BfClient", async () => {
       await showSubtitle("📊 Generating telemetry data...");
-      await new Promise((resolve) => setTimeout(resolve, 3000));
 
       // Use the same org as the dev authentication: boltfoundry.com
       const orgId = "boltfoundry.com";
@@ -164,14 +161,12 @@ Deno.test("Fastpitch telemetry to dashboard flow", async (t) => {
       );
 
       await showSubtitle("✅ Telemetry sent successfully");
-      await new Promise((resolve) => setTimeout(resolve, 3000));
     });
 
     await t.step(
       "Navigate to decks page and verify real deck appears",
       async () => {
         await showSubtitle("🔍 Checking for real deck in dashboard...");
-        await new Promise((resolve) => setTimeout(resolve, 3000));
 
         // Navigate to /pg/grade/decks (or refresh if already there)
         await navigateTo(context, "/pg/grade/decks");
@@ -200,11 +195,9 @@ Deno.test("Fastpitch telemetry to dashboard flow", async (t) => {
         if (hasFastpitchDeck) {
           logger.info("✅ Found fastpitch test deck in the dashboard!");
           await showSubtitle("✅ Real deck displayed in dashboard!");
-          await new Promise((resolve) => setTimeout(resolve, 3000));
         } else {
           logger.warn("❌ Deck not found - dashboard still showing mock data");
           await showSubtitle("⚠️ Dashboard still showing mock data");
-          await new Promise((resolve) => setTimeout(resolve, 3000));
 
           // Check if we're seeing mock decks instead
           const hasMockDecks =
@@ -221,7 +214,6 @@ Deno.test("Fastpitch telemetry to dashboard flow", async (t) => {
 
     await t.step("Verify deck is in the list", async () => {
       await showSubtitle("📝 Verifying deck appears in list...");
-      await new Promise((resolve) => setTimeout(resolve, 3000));
 
       // Check if we can see the test deck in the list
       const testDeckVisible = await context
@@ -239,11 +231,9 @@ Deno.test("Fastpitch telemetry to dashboard flow", async (t) => {
       if (testDeckVisible) {
         logger.info("✅ Test deck is visible in the deck list!");
         await showSubtitle("✅ Test deck confirmed in list!");
-        await new Promise((resolve) => setTimeout(resolve, 3000));
       } else {
         logger.warn("❌ Test deck not found in the list");
         await showSubtitle("⚠️ Test deck not visible");
-        await new Promise((resolve) => setTimeout(resolve, 3000));
       }
 
       assert(testDeckVisible, "Test deck should be visible in the deck list");

--- a/apps/boltfoundry-com/__tests__/e2e/login-interactive-demo.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/login-interactive-demo.test.e2e.ts
@@ -133,8 +133,7 @@ Deno.test("🎬 Interactive Login Demo - Production Mode", async () => {
     await showTitleCard(
       "Interactive Login Demo",
       "Production Environment Test",
-      3500,
-      { noOpeningAnimation: true },
+      { showDuration: 3500, noOpeningAnimation: true },
     );
     await new Promise((resolve) => setTimeout(resolve, 4000));
 

--- a/infra/bft/lib/container-bot-base.ts
+++ b/infra/bft/lib/container-bot-base.ts
@@ -556,12 +556,28 @@ OPTIONS:
   // Ensure host bridge is running
   await ensureHostBridge();
 
+  // Setup shared directory path for certificate generation
+  const currentPath = dirname(
+    dirname(dirname(dirname(import.meta.url.replace("file://", "")))),
+  );
+  let internalbfDir: string;
+  if (currentPath.includes("/bfmono")) {
+    internalbfDir = currentPath.substring(
+      0,
+      currentPath.lastIndexOf("/bfmono"),
+    );
+  } else {
+    internalbfDir = currentPath;
+  }
+  const sharedPath = join(internalbfDir, "bfmono", "shared");
+
   // Ensure wildcard certificate for HTTPS support
-  const homeDir = getConfigurationVariable("HOME");
-  const sharedCertDir = `${homeDir}/internalbf/bfmono/shared/certs`;
+  // Use the actual shared path that gets mounted to the container
+  const sharedCertDir = join(sharedPath, "certs");
   await ensureWildcardCertificate(sharedCertDir);
 
   // Check for Claude credentials
+  const homeDir = getConfigurationVariable("HOME");
   const claudeDir = `${homeDir}/.claude`;
 
   try {
@@ -1253,20 +1269,7 @@ OPTIONS:
     }
   }
 
-  // Setup shared directory path
-  const currentPath = dirname(
-    dirname(dirname(dirname(import.meta.url.replace("file://", "")))),
-  );
-  let internalbfDir: string;
-  if (currentPath.includes("/bfmono")) {
-    internalbfDir = currentPath.substring(
-      0,
-      currentPath.lastIndexOf("/bfmono"),
-    );
-  } else {
-    internalbfDir = currentPath;
-  }
-  const sharedPath = join(internalbfDir, "bfmono", "shared");
+  // sharedPath already calculated earlier for certificate generation
 
   // Ensure shared directory exists
   try {

--- a/infra/testing/video-recording/human-mouse-puppeteer.ts
+++ b/infra/testing/video-recording/human-mouse-puppeteer.ts
@@ -125,7 +125,7 @@ export async function humanMoveTo(
     // Fall back to original smooth movement
     const duration = Math.max(
       100,
-      Math.min(1500, (distance / (1200 * speedFactor)) * 1000),
+      Math.min(1500, (distance / (2400 * speedFactor)) * 1000),
     );
     const steps = Math.max(5, Math.ceil(duration / (1000 / 60)));
     const stepDelay = duration / steps;
@@ -148,7 +148,7 @@ export async function humanMoveTo(
   }
 
   // Human-like movement with spline interpolation
-  const baseSpeed = 800; // Base pixels per second
+  const baseSpeed = 1600; // Base pixels per second (2x faster than original)
   const adjustedSpeed = baseSpeed * speedFactor;
 
   // Calculate timing with some randomness

--- a/infra/testing/video-recording/smooth-mouse.ts
+++ b/infra/testing/video-recording/smooth-mouse.ts
@@ -9,7 +9,7 @@ export async function smoothMoveTo(
   page: Page,
   targetX: number,
   targetY: number,
-  pixelsPerSecond = 1200, // Faster movement speed for better visual effect
+  pixelsPerSecond = 2400, // 2x faster movement speed for demo videos
 ): Promise<void> {
   // Get current mouse position from our global state or default to center
   const currentPos = await page.evaluate(() => {
@@ -22,9 +22,9 @@ export async function smoothMoveTo(
     Math.pow(targetX - currentPos.x, 2) + Math.pow(targetY - currentPos.y, 2),
   );
   const duration = Math.max(
-    100,
-    Math.min(1500, (distance / pixelsPerSecond) * 1000),
-  ); // Min 100ms, max 1.5s
+    25,
+    Math.min(800, (distance / pixelsPerSecond) * 1000),
+  ); // Min 25ms, max 0.8s for snappy movements
 
   // Calculate steps to match 60fps (16.67ms per frame)
   // This ensures smooth movement that matches video framerate

--- a/infra/testing/video-recording/video-converter.ts
+++ b/infra/testing/video-recording/video-converter.ts
@@ -25,7 +25,7 @@ export async function convertFramesToVideo(
 ): Promise<VideoConversionResult> {
   const {
     outputFormat = "mp4",
-    framerate = 48, // Default to 48 fps for smoother video
+    framerate = 60, // Default to 60 fps to match browser screencast
     quality = "medium",
     deleteFrames = true,
     preserveFrames = false,


### PR DESCRIPTION

- Move sharedPath calculation before certificate generation
- Use correct shared directory path instead of /home/codebot/internalbf/...
- Remove duplicate sharedPath calculation
- Ensures certificates are created in mounted shared directory
- Fixes containerStartup failing due to missing certificates

Resolves issue where bft codebot containers required manual cert
generation and service startup instead of working automatically.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/212).
* #218
* #217
* #216
* #213
* __->__ #212
* #209
* #208
* #205