### PR TITLE
Remove infrastructure environment requirement for notify-internalbf

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,6 +187,8 @@ jobs:
             if ! command -v kamal &> /dev/null; then
               echo \"Installing kamal gem...\"
               gem install kamal
+              # Add Ruby gem bin directory to PATH
+              export PATH=\"\$PATH:\$HOME/.local/share/gem/ruby/3.3.0/bin\"
             fi
 
             # Deploy with Kamal

--- a/.github/workflows/operations.yml
+++ b/.github/workflows/operations.yml
@@ -133,6 +133,14 @@ jobs:
                 chmod 600 ~/.ssh/id_rsa
                 ssh-keyscan -H \$FLOATING_IP >> ~/.ssh/known_hosts 2>/dev/null || true
 
+                # Install kamal gem if not already installed
+                if ! command -v kamal &> /dev/null; then
+                  echo \"Installing kamal gem...\"
+                  gem install kamal
+                  # Add Ruby gem bin directory to PATH
+                  export PATH=\"\$PATH:\$HOME/.local/share/gem/ruby/3.3.0/bin\"
+                fi
+
                 # Go to app directory and unlock Kamal
                 cd \$GITHUB_WORKSPACE/apps/boltfoundry-com
                 kamal lock release --rolling

--- a/.github/workflows/operations.yml
+++ b/.github/workflows/operations.yml
@@ -37,7 +37,8 @@ concurrency:
 jobs:
   execute-operation:
     runs-on: ubuntu-latest
-    environment: infrastructure
+    # Only use infrastructure environment for terraform/kamal operations, not for notifications
+    environment: ${{ (github.event_name == 'workflow_dispatch' && contains(fromJSON('["terraform-plan", "terraform-apply", "terraform-destroy", "terraform-refresh", "kamal-unlock"]'), inputs.operation)) && 'infrastructure' || '' }}
 
     steps:
       - name: Set operation for push events


### PR DESCRIPTION

The infrastructure environment causes a 5-minute delay due to approval/wait requirements.
Since notify-internalbf is just triggering a repository dispatch and doesn't modify
infrastructure, it doesn't need this protection.

Now only actual infrastructure operations (terraform and kamal) will use the
infrastructure environment, while notify-internalbf runs immediately.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bfmono/pull/215).
* #216
* #205
* __->__ #215
* #214