### PR TITLE
Fix Kamal 2.x healthcheck configuration

### DIFF
--- a/infra/terraform/hetzner/deploy.yml.tpl
+++ b/infra/terraform/hetzner/deploy.yml.tpl
@@ -27,10 +27,12 @@ proxy:
   ssl: false
   host: ${domain}
   app_port: 8000
-  healthcheck:
-    path: /
-    interval: 10
-    timeout: 5
+
+# Health check configuration for Kamal 2.x
+healthcheck:
+  path: /
+  interval: 10
+  timeout: 5
 
 registry:
   # Use GitHub Container Registry for simplicity


### PR DESCRIPTION

Move healthcheck from nested under proxy to top-level configuration
to match Kamal 2.x syntax requirements. This resolves the deployment
error: 'unknown key: healthcheck'.
